### PR TITLE
Toml is not optional anymore, pytest-sugar has issues with pytest 5.4.x.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -275,7 +275,7 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.5.0"
+version = "1.6.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -532,19 +532,6 @@ testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "virtualenv"]
 
 [[package]]
 category = "main"
-description = "pytest-sugar is a plugin for pytest that changes the default look and feel of pytest (e.g. progressbar, show tests that fail instantly)."
-name = "pytest-sugar"
-optional = true
-python-versions = "*"
-version = "0.9.2"
-
-[package.dependencies]
-packaging = ">=14.1"
-pytest = ">=2.9"
-termcolor = ">=1.1.0"
-
-[[package]]
-category = "main"
 description = "World timezone definitions, modern and historical"
 name = "pytz"
 optional = true
@@ -747,17 +734,9 @@ six = ">=1.10.0"
 
 [[package]]
 category = "main"
-description = "ANSII Color formatting for output in terminal."
-name = "termcolor"
-optional = true
-python-versions = "*"
-version = "1.1.0"
-
-[[package]]
-category = "main"
 description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
-optional = true
+optional = false
 python-versions = "*"
 version = "0.10.0"
 
@@ -836,12 +815,12 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [extras]
-checkers = ["asynctest", "bandit", "black", "doc8", "flake8", "flake8-docstrings", "isort", "mypy", "pytest", "toml", "yamllint"]
-docs = ["pygments", "sphinx", "sphinx-rtd-theme", "toml"]
-tests = ["asynctest", "codecov", "pytest", "pytest-aiohttp", "pytest-asyncio", "pytest-cov", "pytest-sugar"]
+checkers = ["asynctest", "bandit", "black", "doc8", "flake8", "flake8-docstrings", "isort", "mypy", "pytest", "yamllint"]
+docs = ["pygments", "sphinx", "sphinx-rtd-theme"]
+tests = ["asynctest", "codecov", "pytest", "pytest-aiohttp", "pytest-asyncio", "pytest-cov"]
 
 [metadata]
-content-hash = "e4feaadc8e0ee43195a1c17cb2c10b69deb918649b0d08c9193f0b84f1ef2745"
+content-hash = "90d6c859f556cfe2910a44543c0c86e79d2570960d9016bb805d66701f50075a"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -985,8 +964,8 @@ imagesize = [
     {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.5.0-py2.py3-none-any.whl", hash = "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"},
-    {file = "importlib_metadata-1.5.0.tar.gz", hash = "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302"},
+    {file = "importlib_metadata-1.6.0-py2.py3-none-any.whl", hash = "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f"},
+    {file = "importlib_metadata-1.6.0.tar.gz", hash = "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"},
 ]
 isort = [
     {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
@@ -1134,10 +1113,6 @@ pytest-cov = [
     {file = "pytest-cov-2.8.1.tar.gz", hash = "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b"},
     {file = "pytest_cov-2.8.1-py2.py3-none-any.whl", hash = "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"},
 ]
-pytest-sugar = [
-    {file = "pytest-sugar-0.9.2.tar.gz", hash = "sha256:fcd87a74b2bce5386d244b49ad60549bfbc4602527797fac167da147983f58ab"},
-    {file = "pytest_sugar-0.9.2-py2.py3-none-any.whl", hash = "sha256:26cf8289fe10880cbbc130bd77398c4e6a8b936d8393b116a5c16121d95ab283"},
-]
 pytz = [
     {file = "pytz-2019.3-py2.py3-none-any.whl", hash = "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d"},
     {file = "pytz-2019.3.tar.gz", hash = "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"},
@@ -1232,9 +1207,6 @@ sphinxcontrib-serializinghtml = [
 stevedore = [
     {file = "stevedore-1.32.0-py2.py3-none-any.whl", hash = "sha256:a4e7dc759fb0f2e3e2f7d8ffe2358c19d45b9b8297f393ef1256858d82f69c9b"},
     {file = "stevedore-1.32.0.tar.gz", hash = "sha256:18afaf1d623af5950cc0f7e75e70f917784c73b652a34a12d90b309451b5500b"},
-]
-termcolor = [
-    {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},
 ]
 toml = [
     {file = "toml-0.10.0-py2.7.egg", hash = "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,14 +55,14 @@ pytest = { version = "5.4.1", optional = true }
 pytest-aiohttp = { version = "0.3.0", optional = true }
 pytest-asyncio = { version = "0.10.0", optional = true }
 pytest-cov = { version = "2.8.1", optional = true }
-pytest-sugar = { version = "0.9.2", optional = true }
+# pytest-sugar = { version = "0.9.2", optional = true }
 sphinx = { version = "2.4.4", optional = true }
 sphinx-rtd-theme = { version = "0.4.3", optional = true }
-toml = { version = "0.10.0", optional = true }
+toml = { version = "0.10.0" }
 yamllint = { version = "1.21.0", optional = true }
 
 [tool.poetry.extras]
-docs= ["pygments", "sphinx", "sphinx-rtd-theme", "toml"]
+docs = ["pygments", "sphinx", "sphinx-rtd-theme"]
 checkers = [
     "asynctest",
     "bandit",
@@ -73,7 +73,6 @@ checkers = [
     "isort",
     "mypy",
     "pytest",
-    "toml",
     "yamllint"
 ]
 tests = [


### PR DESCRIPTION
## Description
Toml is not optional anymore, pytest-sugar has issues with pytest 5.4.x.