### PR TITLE
feat: add switcher protocol type

### DIFF
--- a/scripts/control_device.py
+++ b/scripts/control_device.py
@@ -23,15 +23,14 @@ from pprint import PrettyPrinter
 from typing import Any, Dict, List
 
 from aioswitcher.api import (
-    SWITCHER_DEVICE_TO_TCP_PORT,
     BreezeRemote,
     BreezeRemoteManager,
     Command,
-    SwitcherApi,
+    SwitcherType1Api,
+    SwitcherType2Api,
 )
 from aioswitcher.api.messages import SwitcherThermostatStateResponse
 from aioswitcher.device import (
-    DeviceCategory,
     DeviceState,
     ThermostatFanLevel,
     ThermostatMode,
@@ -263,7 +262,7 @@ def asdict(dc: object, verbose: bool = False) -> Dict[str, Any]:
 
 async def get_state(device_id: str, device_ip: str, verbose: bool) -> None:
     """Use to launch a get_state request."""
-    async with SwitcherApi(device_ip, device_id) as api:
+    async with SwitcherType1Api(device_ip, device_id) as api:
         printer.pprint(asdict(await api.get_state(), verbose))
 
 
@@ -278,9 +277,7 @@ async def control_thermostat(
     verbose: bool = False,
 ):
     """Control Breeze device."""
-    async with SwitcherApi(
-        device_ip, device_id, SWITCHER_DEVICE_TO_TCP_PORT[DeviceCategory.THERMOSTAT]
-    ) as api:
+    async with SwitcherType2Api(device_ip, device_id) as api:
         rm = BreezeRemoteManager()
         resp: SwitcherThermostatStateResponse = await api.get_breeze_state()
 
@@ -306,19 +303,19 @@ async def control_thermostat(
 
 async def turn_on(device_id: str, device_ip: str, timer: int, verbose: bool) -> None:
     """Use to launch a turn_on request."""
-    async with SwitcherApi(device_ip, device_id) as api:
+    async with SwitcherType1Api(device_ip, device_id) as api:
         printer.pprint(asdict(await api.control_device(Command.ON, timer), verbose))
 
 
 async def turn_off(device_id: str, device_ip: str, verbose: bool) -> None:
     """Use to launch a turn_off request."""
-    async with SwitcherApi(device_ip, device_id) as api:
+    async with SwitcherType1Api(device_ip, device_id) as api:
         printer.pprint(asdict(await api.control_device(Command.OFF), verbose))
 
 
 async def set_name(device_id: str, device_ip: str, name: str, verbose: bool):
     """Use to launch a set_name request."""
-    async with SwitcherApi(device_ip, device_id) as api:
+    async with SwitcherType1Api(device_ip, device_id) as api:
         printer.pprint(asdict(await api.set_device_name(name), verbose))
 
 
@@ -327,13 +324,13 @@ async def set_auto_shutdown(
 ):
     """Use to launch a set_auto_shutdown request."""
     td_val = timedelta(hours=hours, minutes=minutes)
-    async with SwitcherApi(device_ip, device_id) as api:
+    async with SwitcherType1Api(device_ip, device_id) as api:
         printer.pprint(asdict(await api.set_auto_shutdown(td_val), verbose))
 
 
 async def get_schedules(device_id: str, device_ip: str, verbose: bool) -> None:
     """Use to launch a get_schedules request."""
-    async with SwitcherApi(device_ip, device_id) as api:
+    async with SwitcherType1Api(device_ip, device_id) as api:
         response = await api.get_schedules()
         if verbose:
             printer.pprint({"unparsed_response": response.unparsed_response})
@@ -347,7 +344,7 @@ async def delete_schedule(
     device_id: str, device_ip: str, schedule_id: str, verbose: bool
 ) -> None:
     """Use to launch a delete_schedule request."""
-    async with SwitcherApi(device_ip, device_id) as api:
+    async with SwitcherType1Api(device_ip, device_id) as api:
         printer.pprint(asdict(await api.delete_schedule(schedule_id), verbose))
 
 
@@ -360,7 +357,7 @@ async def create_schedule(
     verbose: bool,
 ):
     """Use to launch a create_schedule request."""
-    async with SwitcherApi(device_ip, device_id) as api:
+    async with SwitcherType1Api(device_ip, device_id) as api:
         printer.pprint(
             asdict(
                 await api.create_schedule(
@@ -375,9 +372,7 @@ async def create_schedule(
 
 async def stop_shutter(device_id: str, device_ip: str, verbose: bool):
     """Stop shutter."""
-    async with SwitcherApi(
-        device_ip, device_id, SWITCHER_DEVICE_TO_TCP_PORT[DeviceCategory.SHUTTER]
-    ) as api:
+    async with SwitcherType2Api(device_ip, device_id) as api:
         printer.pprint(
             asdict(
                 await api.stop(),
@@ -390,9 +385,7 @@ async def set_shutter_position(
     device_id: str, device_ip: str, position: int, verbose: bool
 ):
     """Use to set the shutter position."""
-    async with SwitcherApi(
-        device_ip, device_id, SWITCHER_DEVICE_TO_TCP_PORT[DeviceCategory.SHUTTER]
-    ) as api:
+    async with SwitcherType2Api(device_ip, device_id) as api:
         printer.pprint(
             asdict(
                 await api.set_position(position),

--- a/scripts/discover_devices.py
+++ b/scripts/discover_devices.py
@@ -24,26 +24,32 @@ from pprint import PrettyPrinter
 from aioswitcher.bridge import (
     SWITCHER_UDP_PORT_TYPE1,
     SWITCHER_UDP_PORT_TYPE2,
+    DeviceType,
     SwitcherBridge,
 )
 from aioswitcher.device import SwitcherBase
 
 printer = PrettyPrinter(indent=4)
 
-_examples = """Executing this script will print a serialized version of the discovered Switcher
+_examples = (
+    """Executing this script will print a serialized version of the discovered Switcher
 devices broadcasting on the local network for 60 seconds.
 You can change the delay by passing an int argument: discover_devices.py 30
 
 Switcher devices uses two protocol types:
-    Protocol type 1 (UDP port 20002), used by: V2, Touch, V4, Mini, Power Plug
-    Protocol type 2 (UDP port 20003), used by: Breeze, Runner, Runner Mini
+    Protocol type 1 (UDP port 20002), used by: """
+    + ", ".join(d.value for d in DeviceType if d.protocol_type == 1)
+    + """
+    Protocol type 2 (UDP port 20003), used by: """
+    + ", ".join(d.value for d in DeviceType if d.protocol_type == 2)
+    + """
 You can change the scanned protocol type by passing an int argument: discover_devices.py -t 1
 
 Note:
     WILL PRINT PRIVATE INFO SUCH AS DEVICE ID AND MAC.
 
 Example output:
-    Switcher devices broadcast a status message every approximantly 4 seconds. This
+    Switcher devices broadcast a status message every approximately 4 seconds. This
     script listens for these messages and prints a serialized version of the to the
     standard output, for example (note the ``device_id`` and ``mac_address`` properties)::
         {   'auto_shutdown': '03:00:00',
@@ -67,6 +73,7 @@ Print only protocol type 1 devices:
 Print only protocol type 2 devices:
     python discover_devices.py -t 2\n
 """  # noqa E501
+)
 
 parser = ArgumentParser(
     description="Discover and print info of Switcher devices",

--- a/src/aioswitcher/api/packets.py
+++ b/src/aioswitcher/api/packets.py
@@ -20,51 +20,51 @@ SCHEDULE_CREATE_DATA_FORMAT = "01{}01{}{}"
 NO_TIMER_REQUESTED = "00000000"
 NON_RECURRING_SCHEDULE = "00"
 # format values are local session id, timestamp
-REQUEST_FORMAT = "{}340001000000000000000000{}00000000000000000000f0fe"
-REQUEST_FORMAT2 = "{}390001000000000000000000{}00000000000000000000f0fe"
+REQUEST_FORMAT_TYPE1 = "{}340001000000000000000000{}00000000000000000000f0fe"
+REQUEST_FORMAT2_TYPE2 = "{}390001000000000000000000{}00000000000000000000f0fe"
 
 REQUEST_FORMAT_BREEZE = "{}000001000000000000000000{}00000000000000000000f0fe"
 PAD_72_ZEROS = "0" * 72
 # format value just timestamp (initial session id is "00000000")
-LOGIN_PACKET = (
-    "fef052000232a10000000000" + REQUEST_FORMAT[2:] + "1c" + PAD_72_ZEROS + "00"
+LOGIN_PACKET_TYPE1 = (
+    "fef052000232a10000000000" + REQUEST_FORMAT_TYPE1[2:] + "1c" + PAD_72_ZEROS + "00"
 )
 
-LOGIN2_PACKET = (
+LOGIN2_PACKET_TYPE2 = (
     "fef030000305a60000000000ff0301000000000000000000{}00000000000000000000f0fe{}00"
 )
 
 # format values are local session id, timestamp, device id
-GET_STATE_PACKET = "fef0300002320103" + REQUEST_FORMAT + "{}00"
+GET_STATE_PACKET_TYPE1 = "fef0300002320103" + REQUEST_FORMAT_TYPE1 + "{}00"
 
 # format values are local session id, timestamp, device id
-GET_STATE_PACKET2 = "fef0300003050103" + REQUEST_FORMAT2 + "{}00"
+GET_STATE_PACKET2_TYPE2 = "fef0300003050103" + REQUEST_FORMAT2_TYPE2 + "{}00"
 
 # format values are local session id, timestamp, device id, command, timer
 SEND_CONTROL_PACKET = (
-    "fef05d0002320102" + REQUEST_FORMAT + "{}" + PAD_72_ZEROS + "000106000{}00{}"
+    "fef05d0002320102" + REQUEST_FORMAT_TYPE1 + "{}" + PAD_72_ZEROS + "000106000{}00{}"
 )
 # format values are local session id, timestamp, device id, auto-off seconds
 SET_AUTO_OFF_SET_PACKET = (
-    "fef05b0002320102" + REQUEST_FORMAT + "{}" + PAD_72_ZEROS + "00040400{}"
+    "fef05b0002320102" + REQUEST_FORMAT_TYPE1 + "{}" + PAD_72_ZEROS + "00040400{}"
 )
 # format values are local session id, timestamp, device id, name
 UPDATE_DEVICE_NAME_PACKET = (
-    "fef0740002320202" + REQUEST_FORMAT + "{}" + PAD_72_ZEROS + "00{}"
+    "fef0740002320202" + REQUEST_FORMAT_TYPE1 + "{}" + PAD_72_ZEROS + "00{}"
 )
 # format values are local session id, timestamp, device id
 GET_SCHEDULES_PACKET = (
-    "fef0570002320102" + REQUEST_FORMAT + "{}" + PAD_72_ZEROS + "00060000"
+    "fef0570002320102" + REQUEST_FORMAT_TYPE1 + "{}" + PAD_72_ZEROS + "00060000"
 )
 # format values are local session id, timestamp, device id, schedule id
 DELETE_SCHEDULE_PACKET = (
-    "fef0580002320102" + REQUEST_FORMAT + "{}" + PAD_72_ZEROS + "000801000{}"
+    "fef0580002320102" + REQUEST_FORMAT_TYPE1 + "{}" + PAD_72_ZEROS + "000801000{}"
 )
 # format values are local session id, timestamp, device id,
 # schedule data =
 #                   (on_off + week + timstate + start_time + end_time)
 CREATE_SCHEDULE_PACKET = (
-    "fef0630002320102" + REQUEST_FORMAT + "{}" + PAD_72_ZEROS + "00030c00ff{}"
+    "fef0630002320102" + REQUEST_FORMAT_TYPE1 + "{}" + PAD_72_ZEROS + "00030c00ff{}"
 )
 # format values are local session id, timestamp, device id, phone id, device-
 # passwored, command length, command

--- a/src/aioswitcher/bridge.py
+++ b/src/aioswitcher/bridge.py
@@ -45,9 +45,9 @@ __all__ = ["SwitcherBridge"]
 logger = getLogger(__name__)
 
 
-# Type 1 devices: Heaters (v2, touch, v4), Plug
+# Protocol type 1 devices: V2, Touch, V4, Mini, Power Plug
 SWITCHER_UDP_PORT_TYPE1 = 20002
-# Type 2 devices: Heaters Breeze, Runners
+# Protocol type 2 devices: Breeze, Runner, Runner Mini
 SWITCHER_UDP_PORT_TYPE2 = 20003
 
 SWITCHER_DEVICE_TO_UDP_PORT = {

--- a/src/aioswitcher/device/__init__.py
+++ b/src/aioswitcher/device/__init__.py
@@ -35,23 +35,24 @@ class DeviceCategory(Enum):
 class DeviceType(Enum):
     """Enum for relaying the type of the switcher devices."""
 
-    MINI = "Switcher Mini", "030f", DeviceCategory.WATER_HEATER
-    POWER_PLUG = "Switcher Power Plug", "01a8", DeviceCategory.POWER_PLUG
-    TOUCH = "Switcher Touch", "030b", DeviceCategory.WATER_HEATER
-    V2_ESP = "Switcher V2 (esp)", "01a7", DeviceCategory.WATER_HEATER
-    V2_QCA = "Switcher V2 (qualcomm)", "01a1", DeviceCategory.WATER_HEATER
-    V4 = "Switcher V4", "0317", DeviceCategory.WATER_HEATER
-    BREEZE = "Switcher Breeze", "0e01", DeviceCategory.THERMOSTAT
-    RUNNER = "Switcher Runner", "0c01", DeviceCategory.SHUTTER
-    RUNNER_MINI = "Switcher Runner Mini", "0c02", DeviceCategory.SHUTTER
+    MINI = "Switcher Mini", "030f", 1, DeviceCategory.WATER_HEATER
+    POWER_PLUG = "Switcher Power Plug", "01a8", 1, DeviceCategory.POWER_PLUG
+    TOUCH = "Switcher Touch", "030b", 1, DeviceCategory.WATER_HEATER
+    V2_ESP = "Switcher V2 (esp)", "01a7", 1, DeviceCategory.WATER_HEATER
+    V2_QCA = "Switcher V2 (qualcomm)", "01a1", 1, DeviceCategory.WATER_HEATER
+    V4 = "Switcher V4", "0317", 1, DeviceCategory.WATER_HEATER
+    BREEZE = "Switcher Breeze", "0e01", 2, DeviceCategory.THERMOSTAT
+    RUNNER = "Switcher Runner", "0c01", 2, DeviceCategory.SHUTTER
+    RUNNER_MINI = "Switcher Runner Mini", "0c02", 2, DeviceCategory.SHUTTER
 
     def __new__(
-        cls, value: str, hex_rep: str, category: DeviceCategory
+        cls, value: str, hex_rep: str, protocol_type: int, category: DeviceCategory
     ) -> "DeviceType":
         """Override the default enum constructor and include extra properties."""
         new_enum = object.__new__(cls)
         new_enum._value = value  # type: ignore
         new_enum._hex_rep = hex_rep  # type: ignore
+        new_enum._protocol_type = protocol_type  # type: ignore
         new_enum._category = category  # type: ignore
         return new_enum
 
@@ -64,6 +65,11 @@ class DeviceType(Enum):
     def hex_rep(self) -> str:
         """Return the hexadecimal representation of the device type."""
         return self._hex_rep  # type: ignore
+
+    @property
+    def protocol_type(self) -> int:
+        """Return the protocol type of the device."""
+        return self._protocol_type  # type: ignore
 
     @property
     def category(self) -> DeviceCategory:

--- a/tests/test_api_packet_crc_signing.py
+++ b/tests/test_api_packet_crc_signing.py
@@ -29,46 +29,34 @@ SUT_DEVICE_ID = "a123bc"
 
 def test_sign_packet_with_crc_key_for_a_random_string_throws_error():
     """Test the sign_packet_with_crc_key tool with a random string unqualified as a packet."""
-    assert_that(sign_packet_with_crc_key).raises(ValueError).when_called_with(
-        "just a regular string"
-    ).is_equal_to("Odd-length string")
+    assert_that(sign_packet_with_crc_key).raises(
+        ValueError
+    ).when_called_with("just a regular string").is_equal_to("Odd-length string")
 
 
-def test_sign_packet_with_crc_key_for_login_packet_returns_signed_packet():
-    """Test the sign_packet_with_crc_key tool for the LOGIN_PACKET."""
+def test_sign_packet_with_crc_key_for_LOGIN_PACKET_TYPE1_returns_signed_packet():
+    """Test the sign_packet_with_crc_key tool for the LOGIN_PACKET_TYPE1."""
     packet = packets.LOGIN_PACKET_TYPE1.format(SUT_TIMESTAMP)
     assert_that(sign_packet_with_crc_key(packet)).is_equal_to(packet + "627f33f1")
 
 
-def test_sign_packet_with_crc_key_for_get_state_packet_returns_signed_packet():
-    """Test the sign_packet_with_crc_key tool for the GET_STATE_PACKET."""
-    packet = packets.GET_STATE_PACKET_TYPE1.format(
-        SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID
-    )
+def test_sign_packet_with_crc_key_for_GET_STATE_PACKET_TYPE1_returns_signed_packet():
+    """Test the sign_packet_with_crc_key tool for the GET_STATE_PACKET_TYPE1."""
+    packet = packets.GET_STATE_PACKET_TYPE1.format(SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID)
     assert_that(sign_packet_with_crc_key(packet)).is_equal_to(packet + "42a9a1b2")
 
 
 def test_sign_packet_with_crc_key_for_send_control_on_with_no_timer_packet_returns_signed_packet():
     """Test the sign_packet_with_crc_key tool for the SEND_CONTROL_PACKET for on state with no timer."""
     packet = packets.SEND_CONTROL_PACKET.format(
-        SUT_SESSION_ID,
-        SUT_TIMESTAMP,
-        SUT_DEVICE_ID,
-        Command.ON.value,
-        packets.NO_TIMER_REQUESTED,
-    )
+        SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID, Command.ON.value, packets.NO_TIMER_REQUESTED)
     assert_that(sign_packet_with_crc_key(packet)).is_equal_to(packet + "cc06bb10")
 
 
 def test_sign_packet_with_crc_key_for_send_control_off_packet_returns_signed_packet():
     """Test the sign_packet_with_crc_key tool for the SEND_CONTROL_PACKET for off state."""
     packet = packets.SEND_CONTROL_PACKET.format(
-        SUT_SESSION_ID,
-        SUT_TIMESTAMP,
-        SUT_DEVICE_ID,
-        Command.OFF.value,
-        packets.NO_TIMER_REQUESTED,
-    )
+        SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID, Command.OFF.value, packets.NO_TIMER_REQUESTED)
     assert_that(sign_packet_with_crc_key(packet)).is_equal_to(packet + "6c432cf4")
 
 
@@ -76,17 +64,14 @@ def test_sign_packet_with_crc_key_for_send_control_on_with_timer_packet_returns_
     """Test the sign_packet_with_crc_key tool for the SEND_CONTROL_PACKET for on state with a 90 minutes timer."""
     timer_minutes = hexlify(pack("<I", 5400)).decode()
     packet = packets.SEND_CONTROL_PACKET.format(
-        SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID, Command.ON.value, timer_minutes
-    )
+        SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID, Command.ON.value, timer_minutes)
     assert_that(sign_packet_with_crc_key(packet)).is_equal_to(packet + "3b30141e")
 
 
 def test_sign_packet_with_crc_key_for_set_auto_off_packet_returns_signed_packet():
     """Test the sign_packet_with_crc_key tool for the SET_AUTO_OFF_SET_PACKET with a 90 minutes auto-shutdown."""
     auto_shutdown = hexlify(pack("<I", 5400)).decode()
-    packet = packets.SET_AUTO_OFF_SET_PACKET.format(
-        SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID, auto_shutdown
-    )
+    packet = packets.SET_AUTO_OFF_SET_PACKET.format(SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID, auto_shutdown)
     assert_that(sign_packet_with_crc_key(packet)).is_equal_to(packet + "3bb1ca55")
 
 
@@ -95,15 +80,11 @@ def test_sign_packet_with_crc_key_for_set_device_name_packet_returns_signed_pack
     desired_name = "my device cool name"
     hex_name = hexlify(desired_name.encode())
     zeros_pad = ("00" * (32 - len(desired_name))).encode()
-    packet = packets.UPDATE_DEVICE_NAME_PACKET.format(
-        SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID, (hex_name + zeros_pad).decode()
-    )
+    packet = packets.UPDATE_DEVICE_NAME_PACKET.format(SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID, (hex_name + zeros_pad).decode())
     assert_that(sign_packet_with_crc_key(packet)).is_equal_to(packet + "1039bc0e")
 
 
 def test_sign_packet_with_crc_key_for_get_schedules_packet_returns_signed_packet():
     """Test the sign_packet_with_crc_key tool for the GET_SCHEDULES_PACKET."""
-    packet = packets.GET_SCHEDULES_PACKET.format(
-        SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID
-    )
+    packet = packets.GET_SCHEDULES_PACKET.format(SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID)
     assert_that(sign_packet_with_crc_key(packet)).is_equal_to(packet + "0efde536")

--- a/tests/test_api_packet_crc_signing.py
+++ b/tests/test_api_packet_crc_signing.py
@@ -29,34 +29,46 @@ SUT_DEVICE_ID = "a123bc"
 
 def test_sign_packet_with_crc_key_for_a_random_string_throws_error():
     """Test the sign_packet_with_crc_key tool with a random string unqualified as a packet."""
-    assert_that(sign_packet_with_crc_key).raises(
-        ValueError
-    ).when_called_with("just a regular string").is_equal_to("Odd-length string")
+    assert_that(sign_packet_with_crc_key).raises(ValueError).when_called_with(
+        "just a regular string"
+    ).is_equal_to("Odd-length string")
 
 
 def test_sign_packet_with_crc_key_for_login_packet_returns_signed_packet():
     """Test the sign_packet_with_crc_key tool for the LOGIN_PACKET."""
-    packet = packets.LOGIN_PACKET.format(SUT_TIMESTAMP)
+    packet = packets.LOGIN_PACKET_TYPE1.format(SUT_TIMESTAMP)
     assert_that(sign_packet_with_crc_key(packet)).is_equal_to(packet + "627f33f1")
 
 
 def test_sign_packet_with_crc_key_for_get_state_packet_returns_signed_packet():
     """Test the sign_packet_with_crc_key tool for the GET_STATE_PACKET."""
-    packet = packets.GET_STATE_PACKET.format(SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID)
+    packet = packets.GET_STATE_PACKET_TYPE1.format(
+        SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID
+    )
     assert_that(sign_packet_with_crc_key(packet)).is_equal_to(packet + "42a9a1b2")
 
 
 def test_sign_packet_with_crc_key_for_send_control_on_with_no_timer_packet_returns_signed_packet():
     """Test the sign_packet_with_crc_key tool for the SEND_CONTROL_PACKET for on state with no timer."""
     packet = packets.SEND_CONTROL_PACKET.format(
-        SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID, Command.ON.value, packets.NO_TIMER_REQUESTED)
+        SUT_SESSION_ID,
+        SUT_TIMESTAMP,
+        SUT_DEVICE_ID,
+        Command.ON.value,
+        packets.NO_TIMER_REQUESTED,
+    )
     assert_that(sign_packet_with_crc_key(packet)).is_equal_to(packet + "cc06bb10")
 
 
 def test_sign_packet_with_crc_key_for_send_control_off_packet_returns_signed_packet():
     """Test the sign_packet_with_crc_key tool for the SEND_CONTROL_PACKET for off state."""
     packet = packets.SEND_CONTROL_PACKET.format(
-        SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID, Command.OFF.value, packets.NO_TIMER_REQUESTED)
+        SUT_SESSION_ID,
+        SUT_TIMESTAMP,
+        SUT_DEVICE_ID,
+        Command.OFF.value,
+        packets.NO_TIMER_REQUESTED,
+    )
     assert_that(sign_packet_with_crc_key(packet)).is_equal_to(packet + "6c432cf4")
 
 
@@ -64,14 +76,17 @@ def test_sign_packet_with_crc_key_for_send_control_on_with_timer_packet_returns_
     """Test the sign_packet_with_crc_key tool for the SEND_CONTROL_PACKET for on state with a 90 minutes timer."""
     timer_minutes = hexlify(pack("<I", 5400)).decode()
     packet = packets.SEND_CONTROL_PACKET.format(
-        SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID, Command.ON.value, timer_minutes)
+        SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID, Command.ON.value, timer_minutes
+    )
     assert_that(sign_packet_with_crc_key(packet)).is_equal_to(packet + "3b30141e")
 
 
 def test_sign_packet_with_crc_key_for_set_auto_off_packet_returns_signed_packet():
     """Test the sign_packet_with_crc_key tool for the SET_AUTO_OFF_SET_PACKET with a 90 minutes auto-shutdown."""
     auto_shutdown = hexlify(pack("<I", 5400)).decode()
-    packet = packets.SET_AUTO_OFF_SET_PACKET.format(SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID, auto_shutdown)
+    packet = packets.SET_AUTO_OFF_SET_PACKET.format(
+        SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID, auto_shutdown
+    )
     assert_that(sign_packet_with_crc_key(packet)).is_equal_to(packet + "3bb1ca55")
 
 
@@ -80,11 +95,15 @@ def test_sign_packet_with_crc_key_for_set_device_name_packet_returns_signed_pack
     desired_name = "my device cool name"
     hex_name = hexlify(desired_name.encode())
     zeros_pad = ("00" * (32 - len(desired_name))).encode()
-    packet = packets.UPDATE_DEVICE_NAME_PACKET.format(SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID, (hex_name + zeros_pad).decode())
+    packet = packets.UPDATE_DEVICE_NAME_PACKET.format(
+        SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID, (hex_name + zeros_pad).decode()
+    )
     assert_that(sign_packet_with_crc_key(packet)).is_equal_to(packet + "1039bc0e")
 
 
 def test_sign_packet_with_crc_key_for_get_schedules_packet_returns_signed_packet():
     """Test the sign_packet_with_crc_key tool for the GET_SCHEDULES_PACKET."""
-    packet = packets.GET_SCHEDULES_PACKET.format(SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID)
+    packet = packets.GET_SCHEDULES_PACKET.format(
+        SUT_SESSION_ID, SUT_TIMESTAMP, SUT_DEVICE_ID
+    )
     assert_that(sign_packet_with_crc_key(packet)).is_equal_to(packet + "0efde536")

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -41,18 +41,14 @@ def udp_broadcast_server():
 
 
 @patch("logging.Logger.info")
-async def test_stopping_before_started_and_establishing_a_connection_should_write_to_the_info_output(
-    mock_info, mock_callback
-):
+async def test_stopping_before_started_and_establishing_a_connection_should_write_to_the_info_output(mock_info, mock_callback):
     bridge = SwitcherBridge(mock_callback, [1234])
     assert_that(bridge.is_running).is_false()
     await bridge.stop()
     mock_info.assert_called_with("udp bridge on port %s not started", 1234)
 
 
-async def test_bridge_operation_as_a_context_manager(
-    unused_udp_port_factory, mock_callback
-):
+async def test_bridge_operation_as_a_context_manager(unused_udp_port_factory, mock_callback):
     port = unused_udp_port_factory()
     async with SwitcherBridge(mock_callback, [port]) as bridge:
         assert_that(bridge.is_running).is_true()
@@ -68,26 +64,15 @@ async def test_bridge_start_and_stop_operations(unused_udp_port_factory, mock_ca
     assert_that(bridge.is_running).is_false()
 
 
-async def test_bridge_callback_loading(
-    udp_broadcast_server, unused_udp_port_factory, mock_callback, resource_path
-):
+async def test_bridge_callback_loading(udp_broadcast_server, unused_udp_port_factory, mock_callback, resource_path):
     port = unused_udp_port_factory()
-    sut_v2_off_datagram = (
-        Path(f"{resource_path}_v2_off.txt").read_text().replace("\n", "").encode()
-    )
-    sut_power_plug_off_datagram = (
-        Path(f"{resource_path}_power_plug_off.txt")
-        .read_text()
-        .replace("\n", "")
-        .encode()
-    )
+    sut_v2_off_datagram = Path(f'{resource_path}_v2_off.txt').read_text().replace('\n', '').encode()
+    sut_power_plug_off_datagram = Path(f'{resource_path}_power_plug_off.txt').read_text().replace('\n', '').encode()
 
     async with SwitcherBridge(mock_callback, [port]):
         udp_broadcast_server.sendto(unhexlify(sut_v2_off_datagram), ("localhost", port))
         await sleep(0.2)
-        udp_broadcast_server.sendto(
-            unhexlify(sut_power_plug_off_datagram), ("localhost", port)
-        )
+        udp_broadcast_server.sendto(unhexlify(sut_power_plug_off_datagram), ("localhost", port))
         await sleep(0.2)
 
     assert_that(mock_callback.call_count).is_equal_to(2)

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -41,22 +41,26 @@ def udp_broadcast_server():
 
 
 @patch("logging.Logger.info")
-async def test_stopping_before_started_and_establishing_a_connection_should_write_to_the_info_output(mock_info, mock_callback):
-    bridge = SwitcherBridge(mock_callback)
+async def test_stopping_before_started_and_establishing_a_connection_should_write_to_the_info_output(
+    mock_info, mock_callback
+):
+    bridge = SwitcherBridge(mock_callback, [1234])
     assert_that(bridge.is_running).is_false()
     await bridge.stop()
-    mock_info.assert_called_with("udp bridge not started")
+    mock_info.assert_called_with("udp bridge on port %s not started", 1234)
 
 
-async def test_bridge_operation_as_a_context_manager(unused_udp_port_factory, mock_callback):
+async def test_bridge_operation_as_a_context_manager(
+    unused_udp_port_factory, mock_callback
+):
     port = unused_udp_port_factory()
-    async with SwitcherBridge(mock_callback, port) as bridge:
+    async with SwitcherBridge(mock_callback, [port]) as bridge:
         assert_that(bridge.is_running).is_true()
 
 
 async def test_bridge_start_and_stop_operations(unused_udp_port_factory, mock_callback):
     port = unused_udp_port_factory()
-    bridge = SwitcherBridge(mock_callback, port)
+    bridge = SwitcherBridge(mock_callback, [port])
     assert_that(bridge.is_running).is_false()
     await bridge.start()
     assert_that(bridge.is_running).is_true()
@@ -64,15 +68,26 @@ async def test_bridge_start_and_stop_operations(unused_udp_port_factory, mock_ca
     assert_that(bridge.is_running).is_false()
 
 
-async def test_bridge_callback_loading(udp_broadcast_server, unused_udp_port_factory, mock_callback, resource_path):
+async def test_bridge_callback_loading(
+    udp_broadcast_server, unused_udp_port_factory, mock_callback, resource_path
+):
     port = unused_udp_port_factory()
-    sut_v2_off_datagram = Path(f'{resource_path}_v2_off.txt').read_text().replace('\n', '').encode()
-    sut_power_plug_off_datagram = Path(f'{resource_path}_power_plug_off.txt').read_text().replace('\n', '').encode()
+    sut_v2_off_datagram = (
+        Path(f"{resource_path}_v2_off.txt").read_text().replace("\n", "").encode()
+    )
+    sut_power_plug_off_datagram = (
+        Path(f"{resource_path}_power_plug_off.txt")
+        .read_text()
+        .replace("\n", "")
+        .encode()
+    )
 
-    async with SwitcherBridge(mock_callback, port):
+    async with SwitcherBridge(mock_callback, [port]):
         udp_broadcast_server.sendto(unhexlify(sut_v2_off_datagram), ("localhost", port))
         await sleep(0.2)
-        udp_broadcast_server.sendto(unhexlify(sut_power_plug_off_datagram), ("localhost", port))
+        udp_broadcast_server.sendto(
+            unhexlify(sut_power_plug_off_datagram), ("localhost", port)
+        )
         await sleep(0.2)
 
     assert_that(mock_callback.call_count).is_equal_to(2)

--- a/tests/test_udp_datagram_parsing.py
+++ b/tests/test_udp_datagram_parsing.py
@@ -24,24 +24,16 @@ from aioswitcher.bridge import DatagramParser
 from aioswitcher.device import DeviceState, DeviceType
 
 
-@mark.parametrize(
-    "type_suffix, expected_type",
-    [
-        ("mini", DeviceType.MINI),
-        ("power_plug", DeviceType.POWER_PLUG),
-        ("touch", DeviceType.TOUCH),
-        ("v2_esp", DeviceType.V2_ESP),
-        ("v2_qca", DeviceType.V2_QCA),
-        ("v4", DeviceType.V4),
-    ],
-)
+@mark.parametrize("type_suffix, expected_type", [
+    ("mini", DeviceType.MINI),
+    ("power_plug", DeviceType.POWER_PLUG),
+    ("touch", DeviceType.TOUCH),
+    ("v2_esp", DeviceType.V2_ESP),
+    ("v2_qca", DeviceType.V2_QCA),
+    ("v4", DeviceType.V4),
+])
 def test_datagram_state_off(resource_path, type_suffix, expected_type):
-    sut_datagram = (
-        Path(f"{resource_path}_{type_suffix}.txt")
-        .read_text()
-        .replace("\n", "")
-        .encode()
-    )
+    sut_datagram = Path(f'{resource_path}_{type_suffix}.txt').read_text().replace('\n', '').encode()
 
     sut_parser = DatagramParser(unhexlify(sut_datagram))
 
@@ -58,24 +50,16 @@ def test_datagram_state_off(resource_path, type_suffix, expected_type):
         assert_that(sut_parser.get_auto_shutdown()).is_equal_to("03:00:00")
 
 
-@mark.parametrize(
-    "type_suffix, expected_type",
-    [
-        ("mini", DeviceType.MINI),
-        ("power_plug", DeviceType.POWER_PLUG),
-        ("touch", DeviceType.TOUCH),
-        ("v2_esp", DeviceType.V2_ESP),
-        ("v2_qca", DeviceType.V2_QCA),
-        ("v4", DeviceType.V4),
-    ],
-)
+@mark.parametrize("type_suffix, expected_type", [
+    ("mini", DeviceType.MINI),
+    ("power_plug", DeviceType.POWER_PLUG),
+    ("touch", DeviceType.TOUCH),
+    ("v2_esp", DeviceType.V2_ESP),
+    ("v2_qca", DeviceType.V2_QCA),
+    ("v4", DeviceType.V4),
+])
 def test_datagram_state_on(resource_path, type_suffix, expected_type):
-    sut_datagram = (
-        Path(f"{resource_path}_{type_suffix}.txt")
-        .read_text()
-        .replace("\n", "")
-        .encode()
-    )
+    sut_datagram = Path(f'{resource_path}_{type_suffix}.txt').read_text().replace('\n', '').encode()
 
     sut_parser = DatagramParser(unhexlify(sut_datagram))
 
@@ -94,11 +78,6 @@ def test_datagram_state_on(resource_path, type_suffix, expected_type):
 
 @mark.parametrize("type_suffix", ["too_short", "wrong_start"])
 def test_a_faulty_datagram(resource_path, type_suffix):
-    sut_datagram = (
-        Path(f"{resource_path}_{type_suffix}.txt")
-        .read_text()
-        .replace("\n", "")
-        .encode()
-    )
+    sut_datagram = Path(f'{resource_path}_{type_suffix}.txt').read_text().replace('\n', '').encode()
     sut_parser = DatagramParser(unhexlify(sut_datagram))
     assert_that(sut_parser.is_switcher_originator()).is_false()

--- a/tests/test_udp_datagram_parsing.py
+++ b/tests/test_udp_datagram_parsing.py
@@ -24,21 +24,29 @@ from aioswitcher.bridge import DatagramParser
 from aioswitcher.device import DeviceState, DeviceType
 
 
-@mark.parametrize("type_suffix, expected_type", [
-    ("mini", DeviceType.MINI),
-    ("power_plug", DeviceType.POWER_PLUG),
-    ("touch", DeviceType.TOUCH),
-    ("v2_esp", DeviceType.V2_ESP),
-    ("v2_qca", DeviceType.V2_QCA),
-    ("v4", DeviceType.V4),
-])
+@mark.parametrize(
+    "type_suffix, expected_type",
+    [
+        ("mini", DeviceType.MINI),
+        ("power_plug", DeviceType.POWER_PLUG),
+        ("touch", DeviceType.TOUCH),
+        ("v2_esp", DeviceType.V2_ESP),
+        ("v2_qca", DeviceType.V2_QCA),
+        ("v4", DeviceType.V4),
+    ],
+)
 def test_datagram_state_off(resource_path, type_suffix, expected_type):
-    sut_datagram = Path(f'{resource_path}_{type_suffix}.txt').read_text().replace('\n', '').encode()
+    sut_datagram = (
+        Path(f"{resource_path}_{type_suffix}.txt")
+        .read_text()
+        .replace("\n", "")
+        .encode()
+    )
 
     sut_parser = DatagramParser(unhexlify(sut_datagram))
 
     assert_that(sut_parser.is_switcher_originator()).is_true()
-    assert_that(sut_parser.get_ip()).is_equal_to("192.168.1.33")
+    assert_that(sut_parser.get_ip_type1()).is_equal_to("192.168.1.33")
     assert_that(sut_parser.get_mac()).is_equal_to("12:A1:A2:1A:BC:1A")
     assert_that(sut_parser.get_name()).is_equal_to("My Switcher Boiler")
     assert_that(sut_parser.get_device_id()).is_equal_to("aaaaaa")
@@ -50,21 +58,29 @@ def test_datagram_state_off(resource_path, type_suffix, expected_type):
         assert_that(sut_parser.get_auto_shutdown()).is_equal_to("03:00:00")
 
 
-@mark.parametrize("type_suffix, expected_type", [
-    ("mini", DeviceType.MINI),
-    ("power_plug", DeviceType.POWER_PLUG),
-    ("touch", DeviceType.TOUCH),
-    ("v2_esp", DeviceType.V2_ESP),
-    ("v2_qca", DeviceType.V2_QCA),
-    ("v4", DeviceType.V4),
-])
+@mark.parametrize(
+    "type_suffix, expected_type",
+    [
+        ("mini", DeviceType.MINI),
+        ("power_plug", DeviceType.POWER_PLUG),
+        ("touch", DeviceType.TOUCH),
+        ("v2_esp", DeviceType.V2_ESP),
+        ("v2_qca", DeviceType.V2_QCA),
+        ("v4", DeviceType.V4),
+    ],
+)
 def test_datagram_state_on(resource_path, type_suffix, expected_type):
-    sut_datagram = Path(f'{resource_path}_{type_suffix}.txt').read_text().replace('\n', '').encode()
+    sut_datagram = (
+        Path(f"{resource_path}_{type_suffix}.txt")
+        .read_text()
+        .replace("\n", "")
+        .encode()
+    )
 
     sut_parser = DatagramParser(unhexlify(sut_datagram))
 
     assert_that(sut_parser.is_switcher_originator()).is_true()
-    assert_that(sut_parser.get_ip()).is_equal_to("192.168.1.33")
+    assert_that(sut_parser.get_ip_type1()).is_equal_to("192.168.1.33")
     assert_that(sut_parser.get_mac()).is_equal_to("12:A1:A2:1A:BC:1A")
     assert_that(sut_parser.get_name()).is_equal_to("My Switcher Boiler")
     assert_that(sut_parser.get_device_id()).is_equal_to("aaaaaa")
@@ -78,6 +94,11 @@ def test_datagram_state_on(resource_path, type_suffix, expected_type):
 
 @mark.parametrize("type_suffix", ["too_short", "wrong_start"])
 def test_a_faulty_datagram(resource_path, type_suffix):
-    sut_datagram = Path(f'{resource_path}_{type_suffix}.txt').read_text().replace('\n', '').encode()
+    sut_datagram = (
+        Path(f"{resource_path}_{type_suffix}.txt")
+        .read_text()
+        .replace("\n", "")
+        .encode()
+    )
     sut_parser = DatagramParser(unhexlify(sut_datagram))
     assert_that(sut_parser.is_switcher_originator()).is_false()


### PR DESCRIPTION
BREAKING CHANGE: SwitcherBridge broadcast ports changed to list

Signed-off-by: thecode <levyshay1@gmail.com>

# Pull Request

Add protocol types support to api and bridge

## Description
- Add protocol type to `DeviceType` enum
- Add `SwitcherType1Api` and `SwitcherType2Api` to api
- Fix `control_device` script to use new api
- Support bridge listening on multiple ports
- Fix `discover_devices` script to support multiple ports with user selection of ports or protocol type

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I have used the conventional commits specification for my commit messages.
- [x] I have signed my commits.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
> 
