### PR TITLE
build: Update the minimal required Poetry version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ classifiers = [
 include = [ "py.typed" ]
 exclude = [ ]
 
-  [tool.poetry.dependencies]
-  python = "^3.9.0"
+[tool.poetry.dependencies]
+python = "^3.9.0"
 
 [tool.poetry.group.dev.dependencies]
 assertpy = "^1.1"
@@ -106,5 +106,5 @@ precision = 2
 skip_covered = true
 
 [build-system]
-requires = [ "poetry-core>=1.0.0" ]
+requires = [ "poetry-core>=1.2.0" ]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
# Pull Request

Update the minimal required Poetry version to v1.2 to support dependency groups.

## Description

It's updated in `requirements.txt`, yet not in `pyproject.toml`
The latter takes advantage of "dependency groups" which are only available since Poetry v1.2

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I have used the conventional commits specification for my commit messages.
- [x] I have signed my commits.
- [x] I will adhere to the project's code of conduct.