### PR TITLE
chore: Avoid get_event_loop() deprecation warning in discover_devices.py

### DIFF
--- a/scripts/discover_devices.py
+++ b/scripts/discover_devices.py
@@ -16,8 +16,8 @@
 
 """Python script for discovering Switcher devices."""
 
+import asyncio
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
-from asyncio import get_event_loop, sleep
 from dataclasses import asdict
 from pprint import PrettyPrinter
 from typing import List
@@ -108,7 +108,7 @@ async def print_devices(delay: int, ports: List[int]) -> None:
         print()
 
     async with SwitcherBridge(on_device_found_callback, broadcast_ports=ports):
-        await sleep(delay)
+        await asyncio.sleep(delay)
 
 
 if __name__ == "__main__":
@@ -122,6 +122,6 @@ if __name__ == "__main__":
         ports = [SWITCHER_UDP_PORT_TYPE1, SWITCHER_UDP_PORT_TYPE2]
 
     try:
-        get_event_loop().run_until_complete(print_devices(args.delay, ports))
+        asyncio.run(print_devices(args.delay, ports))
     except KeyboardInterrupt:
         exit()


### PR DESCRIPTION
# Pull Request

## Description

From Python 3.11, it will not be valid to call `get_event_loop()` if there is no running event loop already.

Python 3.10 already shows deprecation warnings:
> DeprecationWarning: There is no current event loop

From the [docs](https://docs.python.org/3.10/library/asyncio-eventloop.html#asyncio.get_event_loop):
> Deprecated since version 3.10: Deprecation warning is emitted if there is no running event loop. In future Python releases, this function will be an alias of get_running_loop().

Instead, this commit switches to `asyncio.run(..)` to create an event loop and start the device scanning.

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I have used the conventional commits specification for my commit messages.
- [x] I have signed my commits.
- [x] I will adhere to the project's code of conduct.
