### PR TITLE
build: introduced gnu make

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -40,3 +40,7 @@ trim_trailing_whitespace = true
 
 [**.{json,all-contributorsrc}]
 indent_size = 2
+
+[Makefile*]
+indent_style = tab
+indent_size = 4

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to `aioswitcher`</br>[![conventional-commits]][0]
+# Contributing to `aioswitcher`</br>[![conventional-commits-badge]][conventional-commits-site]
 
 :clap: First off, thank you for taking the time to contribute. :clap:
 
@@ -23,8 +23,7 @@ pip install git+https://github.com/TomerFi/aioswitcher#dev
 
 ## Prepare the environment
 
-With [Python >= 3.10](https://www.python.org/) use [pip](https://pypi.org/project/pip/) to install
-[poetry](https://poetry.eustace.io/) and the used extensions (mainly [poethepoet](https://github.com/nat-n/poethepoet)):
+With [Python >= 3.10][python-site] use [pip][pip-docs] to install [poetry][poetry-site]:
 
 ```shell
   pip install -r requirements.txt
@@ -32,42 +31,46 @@ With [Python >= 3.10](https://www.python.org/) use [pip](https://pypi.org/projec
 
 ## Get started
 
-Install the project in a virtual environment:
+### Get started using make
+
+If you prefer using _GNU_'s [make][make-manual], here are some targets to get you started:
 
 ```shell
-poetry install
+make install # install all dependencies and the current project
+make test # will run all unit-tests
+make lint # will lint the project using black, flake8, isort, mypy, and yamllint
+make docs-serve # will build and serve a local version of the documentation site
 ```
 
-Scroll around [pyproject.toml](../pyproject.toml) and get familiarize with the project,
-pay attention to the following section, as most of the developing steps will use these scripts:
+### Get started using poethepoet
 
-```toml
-[tool.poe.tasks]
+If you prefer using _Python_'s [poethepoet][poethepoet-site], here are some scripts to get you started:
+
+```shell
+poetry run poe install # install all dependencies and the current project
+poetry run poe test # will run all unit-tests
+poetry run poe lint # will lint the project using black, flake8, isort, mypy, and yamllint
+poetry run poe docs_serve # will build and serve a local version of the documentation site
 ```
-
-To get you going, here are some poe scripts I use constantly while working on *aioswitcher*:
-
-- `poetry run poe lint`
-- `poetry run poe test`
-- `poetry run poe test_cov --cov-report html`
-- `poetry run poe lic_check` (requires *deno*)
-- `poetry run poe black_fix`
-- `poetry run poe isort_fix`
-- `poetry run poe docs_build`
 
 ## Commit messages
 
 Commit messages must:
 
-- adhere the [Conventional Commits Specification][0]
-- be signed-off based on the [Developer Certificate of Origin][1]
+- adhere the [Conventional Commits Specifications][conventional-commits-site]
+- be signed-off based on the [Developer Certificate of Origin][developer-certificate-origin]
 
 ## Code of Conduct
 
-Please check the [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+Please check the [CODE_OF_CONDUCT.md][code-of-conduct-github].
 
-<!-- Real Links -->
-[0]: https://conventionalcommits.org
-[1]: https://developercertificate.org
-<!-- Badges Links -->
-[conventional-commits]: https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg
+<!-- Links -->
+[code-of-conduct-github]: https://github.com/TomerFi/.github/blob/main/.github/CODE_OF_CONDUCT.md
+[conventional-commits-badge]: https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg
+[conventional-commits-site]: https://conventionalcommits.org
+[developer-certificate-origin]: https://developercertificate.org
+[make-manual]: https://www.gnu.org/software/make/manual/make.html
+[pip-docs]: https://pypi.org/project/pip/
+[poethepoet-site]: https://github.com/nat-n/poethepoet
+[poetry-site]: https://poetry.eustace.io/
+[python-site]: https://www.python.org/

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Build documentation site
         run: |
-          poetry install --no-interaction --without dev
-          poetry run poe docs_build
+          make install-docs-only-deps
+          make docs-build
 
       - name: Deploy to GH-Pages
         uses: peaceiris/actions-gh-pages@v3.8.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,9 +48,9 @@ jobs:
 
       - name: Lint the project
         run: |
-          poetry install --no-interaction
-          poetry run poe lint
-          poetry run poe lic_check
+          make install-all-deps
+          make lint
+          make verify-license-headers
 
   test:
     runs-on: ubuntu-latest
@@ -95,12 +95,13 @@ jobs:
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python }}
 
       - name: Install project build dependencies
-        run: poetry install --no-interaction
+        run: make install-all-deps
 
       - name: Test the project
         run: >
-          if [ ${{ matrix.python }} == ${{ env.MAIN_PY_VER }} ]; then poetry run poe test_rep;
-          else poetry run poe test; fi
+          if [ ${{ matrix.python }} == ${{ env.MAIN_PY_VER }} ];
+          then make test-with-coverage-reports;
+          else make test; fi
 
       - name: Report test summary
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -151,5 +152,5 @@ jobs:
 
       - name: Build documentation site
         run: |
-          poetry install --no-interaction
-          poetry run poe docs_build
+          make install-all-deps
+          make docs-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,13 +97,11 @@ jobs:
 
       - name: Verify documentation site build
         run: |
-          poetry install --no-interaction --without dev
-          poetry run poe docs_build
+          make install-docs-only-deps
+          make docs-build
 
       - name: Publish build to PyPi
-        run: >
-          poetry publish --build -u __token__
-          -p ${{ secrets[needs.secrets_keys.outputs.pypi_token] }}
+        run: PYPI_TOKEN="${{ secrets[needs.secrets_keys.outputs.pypi_token] }}" make publish
 
       - name: Set development project version
         uses: ciiiii/toml-editor@1.0.0

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -49,9 +49,9 @@ jobs:
 
       - name: Install, test with coverage report, and build
         run: |
-          poetry install --no-interaction
-          poetry run poe test_rep
-          poetry build
+          make install-all-deps
+          make test-with-coverage-reports
+          make build
 
       - name: Push to CodeCov
         uses: codecov/codecov-action@v3

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,102 @@
+# Copyright Tomer Figenblat.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#######################
+#### Build targets ####
+#######################
+build: clean-dist
+	poetry build
+
+clean-dist:
+	rm -rf ./dist
+
+install: install-all-deps
+
+install-all-deps:
+	poetry install --no-interaction
+
+install-docs-only-deps:
+	poetry install --no-interaction --without dev
+
+publish: clean-dist # PYPI_TOKEN is required for this target
+	poetry publish --build --no-interaction -u __token__ -p $(PYPI_TOKEN)
+
+.PHONY: build dist publish install install-all-deps install-docs-only-deps
+
+#########################
+#### Testing targets ####
+#########################
+test:
+	poetry run pytest -v
+
+test-with-coverage:
+	poetry run pytest -v --cov --cov-report=term
+
+test-with-coverage-reports:
+	poetry run pytest -v --cov --cov-report=xml:coverage.xml --junit-xml junit.xml
+
+test-pypi-publish: clean-dist # requires testpypi configuration for poetry
+	poetry publish --build --repository testpypi
+
+.PHONY: test test-with-coverage test-with-coverage-reports test-pypi-publish
+
+#########################
+#### Linting targets ####
+#########################
+lint: black flake8 isort mypy yamllint
+
+black:
+	poetry run black --check src/ docs/ scripts/
+
+black-with-fix:
+	poetry run black src/ docs/ scripts/
+
+flake8:
+	poetry run flake8 src/ tests/ docs/ scripts/
+
+isort:
+	poetry run isort --check-only src/ tests/ docs/ scripts/
+
+isort-with-fix:
+	poetry run isort src/ tests/ docs/ scripts/
+
+mypy:
+	poetry run mypy src/ scripts/
+
+yamllint:
+	poetry run yamllint --format colored --strict .
+
+.PHONY: lint black black-with-fix flake8 isort isort-with-fix mypy yamllint
+
+###############################
+#### Documentation targets ####
+###############################
+docs-clean:
+	rm -rf ./site
+
+docs-build:
+	poetry run mkdocs build --strict
+
+docs-serve:
+	poetry run mkdocs serve
+
+.PHONY: docs-build docs-serve
+
+#########################
+#### License targets ####
+#########################
+verify-license-headers: # requires deno (https://deno.land/#installation)
+	deno run --unstable --allow-read https://deno.land/x/license_checker@v3.1.3/main.ts
+
+.PHONY: verify-license-headers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ mkdocstrings-python = "^0.7.1"
 poethepoet = "^0.16.1"
 
 [tool.poe.tasks]
+install = "poetry install --no-interaction"
 test = "poetry run pytest -v"
 test_cov = "poetry run pytest -v --cov --cov-report=term"
 test_rep = "poetry run pytest -v --cov --cov-report=xml:coverage.xml --junit-xml junit.xml"


### PR DESCRIPTION
# Description

Incorporate [make](https://www.gnu.org/software/make/manual/make.html) for managing build tasks without breaking current usage of _poethepoet_.


**Related issue (if any):** resolves #564 


# Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I have used the conventional commits specification for my commit messages.
- [x] I have signed my commits.
- [x] I will adhere to the project's code of conduct.
