### PR TITLE
docs: better community docs

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,71 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socioeconomic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit
+  permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at tomer.figenblat@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 1.4, available [here](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html).
+
+For answers to common questions about this code of conduct, see [faq](https://www.contributor-covenant.org/faq).

--- a/.github/auto-me-bot.yml
+++ b/.github/auto-me-bot.yml
@@ -1,0 +1,14 @@
+# https://github.com/apps/auto-me-bot
+---
+pr:
+  conventionalTitle:
+  tasksList:
+  lifecycleLabels:
+    ignoreDrafts: true
+    labels:
+      reviewRequired: "status: needs review"
+      changesRequested: "status: changes requested"
+      moreReviewsRequired: "status: needs more reviews"
+      reviewStarted: "status: review started"
+      approved: "status: approved"
+      merged: "status: merged"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to `aioswitcher`</br>[![conventional-commits-badge]][conventional-commits-site]
+# Contributing to *aioswitcher*
 
 :clap: First off, thank you for taking the time to contribute. :clap:
 
@@ -31,20 +31,11 @@ With [Python >= 3.10][python-site] use [pip][pip-docs] to install [poetry][poetr
 
 ## Get started
 
-### Get started using make
-
-If you prefer using _GNU_'s [make][make-manual], here are some targets to get you started:
-
-```shell
-make install # install all dependencies and the current project
-make test # will run all unit-tests
-make lint # will lint the project using black, flake8, isort, mypy, and yamllint
-make docs-serve # will build and serve a local version of the documentation site
-```
+Note the [code documentation][aioswitcher-code-docs], hosted in this project's [documentation site][aioswitcher-docs-site].<br/>
 
 ### Get started using poethepoet
 
-If you prefer using _Python_'s [poethepoet][poethepoet-site], here are some scripts to get you started:
+If you prefer using *Python*'s [poethepoet][poethepoet-site], here are some scripts to get you started:
 
 ```shell
 poetry run poe install # install all dependencies and the current project
@@ -53,22 +44,20 @@ poetry run poe lint # will lint the project using black, flake8, isort, mypy, an
 poetry run poe docs_serve # will build and serve a local version of the documentation site
 ```
 
-## Commit messages
+### Get started using make
 
-Commit messages must:
+If you prefer using *GNU*'s [make][make-manual], here are some targets to get you started:
 
-- adhere the [Conventional Commits Specifications][conventional-commits-site]
-- be signed-off based on the [Developer Certificate of Origin][developer-certificate-origin]
-
-## Code of Conduct
-
-Please check the [CODE_OF_CONDUCT.md][code-of-conduct-github].
+```shell
+make install # install all dependencies and the current project
+make test # will run all unit-tests
+make lint # will lint the project using black, flake8, isort, mypy, and yamllint
+make docs-serve # will build and serve a local version of the documentation site
+```
 
 <!-- Links -->
-[code-of-conduct-github]: https://github.com/TomerFi/.github/blob/main/.github/CODE_OF_CONDUCT.md
-[conventional-commits-badge]: https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg
-[conventional-commits-site]: https://conventionalcommits.org
-[developer-certificate-origin]: https://developercertificate.org
+[aioswitcher-code-docs]: https://aioswitcher.tomfi.info/codedocs/
+[aioswitcher-docs-site]: https://aioswitcher.tomfi.info/
 [make-manual]: https://www.gnu.org/software/make/manual/make.html
 [pip-docs]: https://pypi.org/project/pip/
 [poethepoet-site]: https://github.com/nat-n/poethepoet

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ pip install aioswitcher
 <table>
   <td><a href="https://aioswitcher.tomfi.info/">Documentation</a></td>
   <td><a href="https://github.com/TomerFi/aioswitcher/wiki">Wiki</a></td>
-  <td><a href="https://github.com/TomerFi/aioswitcher/blob/dev/.github/CONTRIBUTING.md">Contributing</a></td>
-  <td><a href="https://github.com/TomerFi/.github/blob/main/.github/CODE_OF_CONDUCT.md">Code of Conduct</a></td>
+  <td><a href="https://github.com/TomerFi/aioswitcher/blob/dev/CONTRIBUTING.md">Contributing</a></td>
 </table>
 
 ## Example Usage


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->
## Description

- ci: added individual auto-me-bot configuration
- chore: moved code of conduct to current project
- docs: update the contribution guidelines and moved them to root easy access

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

auto-me-bot is now **enforcing conventional pr titles instead of conventional commit messages**,
plus the **sign-off trailer is no longer being enforced** although still encouraged and added automatically to web-based commits.
