### PR TITLE
fix: remove raise in SwitcherBreezeRemoteManager init

### DIFF
--- a/src/aioswitcher/api/remotes.py
+++ b/src/aioswitcher/api/remotes.py
@@ -18,7 +18,6 @@ import re
 from binascii import hexlify
 from json import load
 from logging import getLogger
-from os import path
 from pathlib import Path
 from typing import Any, Dict, List, Union, final
 
@@ -418,11 +417,6 @@ class SwitcherBreezeRemoteManager:
         """Initialize the Remote manager."""
         self._remotes_db: Dict[str, SwitcherBreezeRemote] = {}
         self._remotes_db_fpath = remotes_db_path
-        # verify the file exists
-        if not path.isfile(self._remotes_db_fpath):
-            raise OSError(
-                f"The specified remote db path {self._remotes_db_fpath} does not exist"
-            )
 
     def get_remote(self, remote_id: str) -> SwitcherBreezeRemote:
         """Get Breeze remote by the remote id.

--- a/tests/test_api_tcp_client.py
+++ b/tests/test_api_tcp_client.py
@@ -307,12 +307,6 @@ async def test_breeze_get_command_function_should_raise_command_does_not_eixst(r
     assert_that(command.command).is_equal_to(hexlify(elec7001_turn_off_cmd).decode())
 
 
-async def test_breeze_remote_manager_with_none_existing_remotes_db():
-    local_remotes_db = "/wrong/directory/remotes_db.json"
-    with raises(OSError, match=f"The specified remote db path {local_remotes_db} does not exist"):
-        SwitcherBreezeRemoteManager(local_remotes_db)
-
-
 async def test_breeze_remote_manager_get_from_local_database():
     remote_manager = SwitcherBreezeRemoteManager()
     remote_7022 = remote_manager.get_remote("ELEC7022")


### PR DESCRIPTION
Signed-off-by: Shay Levy <levyshay1@gmail.com>

<!-- markdownlint-disable MD041-->
## Description
Remove raise in class init, see https://github.com/home-assistant/core/pull/81245#discussion_r1035555924
> Describe what you did and why.

**Related issue (if any):** fixes #issue_number_goes_here

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
