### PR TITLE
feat: include bridge port 10002, used in new devices in broadcast discovery

### DIFF
--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -20,7 +20,7 @@ devices broadcasting on the local network for 60 seconds.
 You can change the delay by passing an int argument: discover_devices.py 30
 
 Switcher devices uses two protocol types:
-    Protocol type 1 (UDP port 20002), used by: Switcher Mini, Switcher Power Plug, Switcher Touch, Switcher V2 (esp), Switcher V2 (qualcomm), Switcher V4
+    Protocol type 1 (UDP port 20002 or port 10002), used by: Switcher Mini, Switcher Power Plug, Switcher Touch, Switcher V2 (esp), Switcher V2 (qualcomm), Switcher V4
     Protocol type 2 (UDP port 20003), used by: Switcher Breeze, Switcher Runner, Switcher Runner Mini
 You can change the scanned protocol type by passing an int argument: discover_devices.py -t 1
 

--- a/scripts/discover_devices.py
+++ b/scripts/discover_devices.py
@@ -38,7 +38,7 @@ devices broadcasting on the local network for 60 seconds.
 You can change the delay by passing an int argument: discover_devices.py 30
 
 Switcher devices uses two protocol types:
-    Protocol type 1 (UDP port 20002), used by: """
+    Protocol type 1 (UDP port 20002 or 10002), used by: """
     + ", ".join(d.value for d in DeviceType if d.protocol_type == 1)
     + """
     Protocol type 2 (UDP port 20003), used by: """

--- a/scripts/discover_devices.py
+++ b/scripts/discover_devices.py
@@ -24,6 +24,7 @@ from typing import List
 
 from aioswitcher.bridge import (
     SWITCHER_UDP_PORT_TYPE1,
+    SWITCHER_UDP_PORT_TYPE1_NEW_VERSION,
     SWITCHER_UDP_PORT_TYPE2,
     SwitcherBridge,
 )
@@ -115,11 +116,15 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.type == "1":
-        ports = [SWITCHER_UDP_PORT_TYPE1]
+        ports = [SWITCHER_UDP_PORT_TYPE1, SWITCHER_UDP_PORT_TYPE1_NEW_VERSION]
     elif args.type == "2":
         ports = [SWITCHER_UDP_PORT_TYPE2]
     else:
-        ports = [SWITCHER_UDP_PORT_TYPE1, SWITCHER_UDP_PORT_TYPE2]
+        ports = [
+            SWITCHER_UDP_PORT_TYPE1,
+            SWITCHER_UDP_PORT_TYPE1_NEW_VERSION,
+            SWITCHER_UDP_PORT_TYPE2,
+        ]
 
     try:
         asyncio.run(print_devices(args.delay, ports))

--- a/src/aioswitcher/bridge.py
+++ b/src/aioswitcher/bridge.py
@@ -47,6 +47,7 @@ logger = getLogger(__name__)
 
 # Protocol type 1 devices: V2, Touch, V4, Mini, Power Plug
 SWITCHER_UDP_PORT_TYPE1 = 20002
+SWITCHER_UDP_PORT_TYPE1_NEW_VERSION = 10002
 # Protocol type 2 devices: Breeze, Runner, Runner Mini
 SWITCHER_UDP_PORT_TYPE2 = 20003
 
@@ -166,14 +167,19 @@ class SwitcherBridge:
     Args:
         on_device: a callable to which every new SwitcherBase device found will be send.
         broadcast_ports: broadcast ports list, default for type 1 devices is 20002,
-            default for type 2 devices is 20003
+            default for type 2 devices is 20003.
+            On newer type1 devices, the port is 10002.
 
     """
 
     def __init__(
         self,
         on_device: Callable[[SwitcherBase], Any],
-        broadcast_ports: List[int] = [SWITCHER_UDP_PORT_TYPE1, SWITCHER_UDP_PORT_TYPE2],
+        broadcast_ports: List[int] = [
+            SWITCHER_UDP_PORT_TYPE1,
+            SWITCHER_UDP_PORT_TYPE1_NEW_VERSION,
+            SWITCHER_UDP_PORT_TYPE2,
+        ],
     ) -> None:
         """Initialize the switcher bridge."""
         self._on_device = on_device


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->
## Description

> In newer firmware version of Switcher V2, the broadcast port changed from 20002 to 10002. I added this port to the bridge discovery code.

**Related issue (if any):** fixes #592

## Checklist

- [V] I have followed this repository's contributing guidelines.
- [V] I will adhere to the project's code of conduct.
