### PR TITLE
feat: include bridge port 10003 for type2 devices

### DIFF
--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -21,7 +21,7 @@ You can change the delay by passing an int argument: discover_devices.py 30
 
 Switcher devices uses two protocol types:
     Protocol type 1 (UDP port 20002 or port 10002), used by: Switcher Mini, Switcher Power Plug, Switcher Touch, Switcher V2 (esp), Switcher V2 (qualcomm), Switcher V4
-    Protocol type 2 (UDP port 20003), used by: Switcher Breeze, Switcher Runner, Switcher Runner Mini
+    Protocol type 2 (UDP port 20003 or port 10003), used by: Switcher Breeze, Switcher Runner, Switcher Runner Mini
 You can change the scanned protocol type by passing an int argument: discover_devices.py -t 1
 
 Note:

--- a/scripts/discover_devices.py
+++ b/scripts/discover_devices.py
@@ -26,6 +26,7 @@ from aioswitcher.bridge import (
     SWITCHER_UDP_PORT_TYPE1,
     SWITCHER_UDP_PORT_TYPE1_NEW_VERSION,
     SWITCHER_UDP_PORT_TYPE2,
+    SWITCHER_UDP_PORT_TYPE2_NEW_VERSION,
     SwitcherBridge,
 )
 from aioswitcher.device import DeviceType, SwitcherBase
@@ -41,7 +42,7 @@ Switcher devices uses two protocol types:
     Protocol type 1 (UDP port 20002 or 10002), used by: """
     + ", ".join(d.value for d in DeviceType if d.protocol_type == 1)
     + """
-    Protocol type 2 (UDP port 20003), used by: """
+    Protocol type 2 (UDP port 20003 or 10003), used by: """
     + ", ".join(d.value for d in DeviceType if d.protocol_type == 2)
     + """
 You can change the scanned protocol type by passing an int argument: discover_devices.py -t 1
@@ -118,12 +119,13 @@ if __name__ == "__main__":
     if args.type == "1":
         ports = [SWITCHER_UDP_PORT_TYPE1, SWITCHER_UDP_PORT_TYPE1_NEW_VERSION]
     elif args.type == "2":
-        ports = [SWITCHER_UDP_PORT_TYPE2]
+        ports = [SWITCHER_UDP_PORT_TYPE2, SWITCHER_UDP_PORT_TYPE2_NEW_VERSION]
     else:
         ports = [
             SWITCHER_UDP_PORT_TYPE1,
             SWITCHER_UDP_PORT_TYPE1_NEW_VERSION,
             SWITCHER_UDP_PORT_TYPE2,
+            SWITCHER_UDP_PORT_TYPE2_NEW_VERSION,
         ]
 
     try:

--- a/src/aioswitcher/bridge.py
+++ b/src/aioswitcher/bridge.py
@@ -50,6 +50,7 @@ SWITCHER_UDP_PORT_TYPE1 = 20002
 SWITCHER_UDP_PORT_TYPE1_NEW_VERSION = 10002
 # Protocol type 2 devices: Breeze, Runner, Runner Mini
 SWITCHER_UDP_PORT_TYPE2 = 20003
+SWITCHER_UDP_PORT_TYPE2_NEW_VERSION = 10003
 
 SWITCHER_DEVICE_TO_UDP_PORT = {
     DeviceCategory.WATER_HEATER: SWITCHER_UDP_PORT_TYPE1,
@@ -169,6 +170,7 @@ class SwitcherBridge:
         broadcast_ports: broadcast ports list, default for type 1 devices is 20002,
             default for type 2 devices is 20003.
             On newer type1 devices, the port is 10002.
+            On newer type2 devices, the port is 10003.
 
     """
 
@@ -179,6 +181,7 @@ class SwitcherBridge:
             SWITCHER_UDP_PORT_TYPE1,
             SWITCHER_UDP_PORT_TYPE1_NEW_VERSION,
             SWITCHER_UDP_PORT_TYPE2,
+            SWITCHER_UDP_PORT_TYPE2_NEW_VERSION,
         ],
     ) -> None:
         """Initialize the switcher bridge."""


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->
## Description

> In newer firmware version of Runner S11 and Runner S12, the broadcast port changed from 20003 to 10003. I added this port to the bridge discovery code.


## Checklist

- [X] I have followed this repository's contributing guidelines.
- [X] I will adhere to the project's code of conduct.

## Additional information
This PR is to support the new Switcher Port and prepare for Runner S11 support.

The Switcher team is moving to Token based authentication.
I contact them and they give me the Token code for Python.
Need to implement this System because soon all their devices will work only with Token.
 