### PR TITLE
fix: allow date rollover when comparing times

### DIFF
--- a/src/aioswitcher/schedule/tools.py
+++ b/src/aioswitcher/schedule/tools.py
@@ -16,7 +16,7 @@
 
 import time
 from binascii import hexlify
-from datetime import datetime
+from datetime import datetime, timedelta
 from struct import pack
 from typing import Set, Union
 
@@ -73,9 +73,9 @@ def calc_duration(start_time: str, end_time: str) -> str:
     """Use to calculate the delta between two time values formated as %H:%M."""
     start_datetime = datetime.strptime(start_time, "%H:%M")
     end_datetime = datetime.strptime(end_time, "%H:%M")
-    if end_datetime > start_datetime:
-        return str(end_datetime - start_datetime)
-    raise ValueError("end_time should be greater the start_time")
+    if end_datetime < start_datetime:
+        end_datetime += timedelta(days=1)
+    return str(end_datetime - start_datetime)
 
 
 def bit_summary_to_days(sum_weekdays_bit: int) -> Set[Days]:

--- a/tests/test_schedule_tools.py
+++ b/tests/test_schedule_tools.py
@@ -89,10 +89,8 @@ def test_calc_duration_with_valid_start_and_end_time_should_return_the_duration(
     assert_that(tools.calc_duration("13:00", "14:00")).is_equal_to("1:00:00")
 
 
-def test_calc_duration_with_reveresed_start_and_end_time_should_throw_an_error():
-    assert_that(tools.calc_duration).raises(
-        ValueError
-    ).when_called_with("14:00", "13:00").is_equal_to("end_time should be greater the start_time")
+def test_calc_duration_with_greater_start_time_than_end_time_should_assume_next_day():
+    assert_that(tools.calc_duration("14:00", "13:00")).is_equal_to("11:00:00")
 
 
 def test_hexadecimale_timestamp_to_localtime_with_the_current_timestamp_should_return_a_time_string():

--- a/tests/test_schedule_tools.py
+++ b/tests/test_schedule_tools.py
@@ -90,7 +90,7 @@ def test_calc_duration_with_valid_start_and_end_time_should_return_the_duration(
 
 
 def test_calc_duration_with_greater_start_time_than_end_time_should_assume_next_day():
-    assert_that(tools.calc_duration("14:00", "13:00")).is_equal_to("11:00:00")
+    assert_that(tools.calc_duration("14:00", "13:00")).is_equal_to("23:00:00")
 
 
 def test_hexadecimale_timestamp_to_localtime_with_the_current_timestamp_should_return_a_time_string():


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->
## Description

modified calc_duration method in tools.py to allow for a situation where end_time is less than start_time due to in being in the next day. Switcher allows this condition and currently getting such a schedule would result in an exception

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

