### PR TITLE
fix(typing): move py.typed to src dir

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Typing :: Typed"
 ]
-include = [ "py.typed" ]
+include = [ ]
 exclude = [ ]
 
   [tool.poetry.dependencies]


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->
## Description
Including the `py.typed` from the root will install it directly into `lib/python3.12/site-packages/py.typed` which breaks type checkers like pyright. Instead it should be move to the to level project folder, i.e. `src/aioswitcher`.

Additionally, it's not necessary to add it to `include`. Poetry will do that automatically.
https://blog.whtsky.me/tech/2021/dont-forget-py.typed-for-your-typed-python-package/#adding-pytyped

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.
