### PR TITLE
fix: incompatible toml-editor version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         uses: tomerfi/version-bumper-action@1.2.2
 
       - name: Set new project version
-        uses: ciiiii/toml-editor@1.0.0
+        uses: sandstromviktor/toml-editor@2.0.0
         with:
           file: pyproject.toml
           key: tool.poetry.version


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->
## Description
The original https://github.com/ciiiii/toml-editor action seems to be unmaintained now. With the recent Github actions updates to node 20+, it has become incompatible.

Switch to a working fork: https://github.com/sandstromviktor/toml-editor
https://github.com/ciiiii/toml-editor/compare/1.0.0...sandstromviktor:toml-editor:2.0.0

> [!NOTE]
> It might be necessary to allow the action in the repo settings.

/CC @thecode

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.