### PR TITLE
fix: ssl deprecation in home assistant

### DIFF
--- a/src/aioswitcher/device/tools.py
+++ b/src/aioswitcher/device/tools.py
@@ -199,7 +199,7 @@ async def validate_token(username: str, token: str) -> bool:
     request_data = {"email": username, "token": token}
     is_token_valid = False
     # Preload the SSL context
-    ssl_context = ssl.SSLContext()
+    ssl_context = ssl.create_default_context()
 
     logger.debug("calling API call for Switcher to validate the token")
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->
## Description

> Using previous code made this deprecation message in Home Assistant when calling this function:
> aioswitcher/device/tools.py:202: DeprecationWarning: ssl.PROTOCOL_TLS is deprecated

> Consulting with ChatGPT I got this answer:
The key change here is replacing:
ssl.SSLContext()
with:
ssl.create_default_context()

> This change does the following:
> - It uses ssl.create_default_context(), which creates a secure default SSL context with modern settings.
> - It avoids the deprecated ssl.PROTOCOL_TLS by using the recommended default settings.
> - It provides better security by using up-to-date SSL/TLS protocols and cipher suites.

**Related issue (if any):** fixes #issue_number_goes_here

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
