### PR TITLE
chore: make a single switcherapi class

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ asyncio.run(print_devices(60))
   ```python
   async def control_power_plug(device_type, device_ip, device_id, device_key) :
       # for connecting to a device we need its type, id, login key and ip address
-      async with SwitcherType1Api(device_type, device_ip, device_id, device_key) as api:
+      async with SwitcherApi(device_type, device_ip, device_id, device_key) as api:
           # get the device current state
           await api.get_state()
           # turn the device on
@@ -62,7 +62,7 @@ asyncio.run(print_devices(60))
   ```python
   async def control_water_heater(device_type, device_ip, device_id, device_key) :
       # for connecting to a device we need its type, id, login key and ip address
-      async with SwitcherType1Api(device_type, device_ip, device_id, device_key) as api:
+      async with SwitcherApi(device_type, device_ip, device_id, device_key) as api:
           # get the device current state
           await api.get_state()
           # turn the device on for 15 minutes
@@ -96,7 +96,7 @@ asyncio.run(print_devices(60))
   ```python
   async def control_runner(device_type, device_ip, device_id, device_key, token) :
       # for connecting to a device we need its type, id, login key and ip address
-      async with SwitcherType2Api(device_type, device_ip, device_id, device_key, token) as api:
+      async with SwitcherApi(device_type, device_ip, device_id, device_key, token) as api:
           # get the shutter current state, circuit number is 0
           await api.get_shutter_state(0)
           # open the shutter to 30%, circuit number is 0
@@ -122,7 +122,7 @@ asyncio.run(print_devices(60))
   ```python
   async def control_breeze(device_type, device_ip, device_id, device_key, remote_manager, remote_id) :
       # for connecting to a device we need its type, id, login key and ip address
-      async with SwitcherType2Api(device_type, device_ip, device_id, device_key) as api:
+      async with SwitcherApi(device_type, device_ip, device_id, device_key) as api:
           # get the device current state
           await api.get_breeze_state()
           # initialize the Breeze RemoteManager and get the remote
@@ -152,7 +152,7 @@ asyncio.run(print_devices(60))
   ```python
   async def control_light(device_type, device_ip, device_id, device_key, token) :
       # for connecting to a device we need its type, id, login key and ip address
-      async with SwitcherType2Api(device_type, device_ip, device_id, device_key, token) as api:
+      async with SwitcherApi(device_type, device_ip, device_id, device_key, token) as api:
           # get the light current state, circuit number is 0
           await api.get_light_state(0)
           # turn on the light, circuit number is 0 (Only for Runner S11, Runner S12 and Lights)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -42,7 +42,7 @@ We can use the Type1 API to gain the following capabilities:
 ```python
 async def control_device(device_type, device_ip, device_id, device_key) :
     # for connecting to a device we need its type, id, login key and ip address
-    async with SwitcherType1Api(device_type, device_ip, device_id, device_key) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key) as api:
         # get the device current state (1)
         await api.get_state()
         # turn the device on for 15 minutes (2)
@@ -102,7 +102,7 @@ We can use the Type2 API to gain the following capabilities on Switcher Breeze, 
 ```python
 async def control_runner(device_type, device_ip, device_id, device_key, token) :
     # for connecting to a device we need its type, id, login key, token and ip address
-    async with SwitcherType2Api(device_type, device_ip, device_id, device_key, token) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key, token) as api:
         # get the shutter current state, circuit number is 0
         await api.get_shutter_state(0)
         # open the shutter to 30%, circuit number is 0
@@ -135,7 +135,7 @@ asyncio.run(
   ```python
   async def control_light(device_type, device_ip, device_id, device_key, token) :
       # for connecting to a device we need its type, id, login key and ip address
-      async with SwitcherType2Api(device_type, device_ip, device_id, device_key, token) as api:
+      async with SwitcherApi(device_type, device_ip, device_id, device_key, token) as api:
           # get the light current state, circuit number is 0
           await api.get_light_state(0)
           # turn on the light, circuit number is 0 (Only for Runner S11, Runner S12 and Lights)
@@ -155,7 +155,7 @@ asyncio.run(
 ```python
 async def control_breeze(device_type, device_ip, device_id, device_key, remote_manager, remote_id) :
     # for connecting to a device we need its type, id, login key and ip address
-    async with SwitcherType2Api(device_type, device_ip, device_id, device_key) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key) as api:
         # get the device current state (1)
         await api.get_breeze_state()
         # initialize the Breeze RemoteManager and get the remote (2)

--- a/scripts/control_device.py
+++ b/scripts/control_device.py
@@ -22,7 +22,7 @@ from datetime import timedelta
 from pprint import PrettyPrinter
 from typing import Any, Dict, List, Union
 
-from aioswitcher.api import Command, SwitcherType1Api, SwitcherType2Api
+from aioswitcher.api import Command, SwitcherApi
 from aioswitcher.api.remotes import SwitcherBreezeRemoteManager
 from aioswitcher.device import (
     DeviceState,
@@ -442,9 +442,7 @@ async def get_thermostat_state(
     token: Union[str, None] = None,
 ) -> None:
     """Use to launch a get_breeze_state request."""
-    async with SwitcherType2Api(
-        device_type, device_ip, device_id, device_key, token
-    ) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key, token) as api:
         printer.pprint(asdict(await api.get_breeze_state(), verbose))
 
 
@@ -458,9 +456,7 @@ async def get_shutter_state(
     token: Union[str, None] = None,
 ) -> None:
     """Use to launch a get_shutter_state request."""
-    async with SwitcherType2Api(
-        device_type, device_ip, device_id, device_key, token
-    ) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key, token) as api:
         printer.pprint(asdict(await api.get_shutter_state(index), verbose))
 
 
@@ -472,7 +468,7 @@ async def get_state(
     verbose: bool,
 ) -> None:
     """Use to launch a get_state request."""
-    async with SwitcherType1Api(device_type, device_ip, device_id, device_key) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key) as api:
         printer.pprint(asdict(await api.get_state(), verbose))
 
 
@@ -492,9 +488,7 @@ async def control_thermostat(
     token: Union[str, None] = None,
 ) -> None:
     """Control Breeze device."""
-    async with SwitcherType2Api(
-        device_type, device_ip, device_id, device_key, token
-    ) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key, token) as api:
         printer.pprint(
             asdict(
                 await api.control_breeze_device(
@@ -520,7 +514,7 @@ async def turn_on(
     verbose: bool,
 ) -> None:
     """Use to launch a turn_on request."""
-    async with SwitcherType1Api(device_type, device_ip, device_id, device_key) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key) as api:
         printer.pprint(asdict(await api.control_device(Command.ON, timer), verbose))
 
 
@@ -532,7 +526,7 @@ async def turn_off(
     verbose: bool,
 ) -> None:
     """Use to launch a turn_off request."""
-    async with SwitcherType1Api(device_type, device_ip, device_id, device_key) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key) as api:
         printer.pprint(asdict(await api.control_device(Command.OFF), verbose))
 
 
@@ -545,7 +539,7 @@ async def set_name(
     verbose: bool,
 ) -> None:
     """Use to launch a set_name request."""
-    async with SwitcherType1Api(device_type, device_ip, device_id, device_key) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key) as api:
         printer.pprint(asdict(await api.set_device_name(name), verbose))
 
 
@@ -560,7 +554,7 @@ async def set_auto_shutdown(
 ) -> None:
     """Use to launch a set_auto_shutdown request."""
     td_val = timedelta(hours=hours, minutes=minutes)
-    async with SwitcherType1Api(device_type, device_ip, device_id, device_key) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key) as api:
         printer.pprint(asdict(await api.set_auto_shutdown(td_val), verbose))
 
 
@@ -572,7 +566,7 @@ async def get_schedules(
     verbose: bool,
 ) -> None:
     """Use to launch a get_schedules request."""
-    async with SwitcherType1Api(device_type, device_ip, device_id, device_key) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key) as api:
         response = await api.get_schedules()
         if verbose:
             printer.pprint({"unparsed_response": response.unparsed_response})
@@ -591,7 +585,7 @@ async def delete_schedule(
     verbose: bool,
 ) -> None:
     """Use to launch a delete_schedule request."""
-    async with SwitcherType1Api(device_type, device_ip, device_id, device_key) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key) as api:
         printer.pprint(asdict(await api.delete_schedule(schedule_id), verbose))
 
 
@@ -606,7 +600,7 @@ async def create_schedule(
     verbose: bool,
 ) -> None:
     """Use to launch a create_schedule request."""
-    async with SwitcherType1Api(device_type, device_ip, device_id, device_key) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key) as api:
         printer.pprint(
             asdict(
                 await api.create_schedule(
@@ -629,9 +623,7 @@ async def stop_shutter(
     token: Union[str, None] = None,
 ) -> None:
     """Stop shutter."""
-    async with SwitcherType2Api(
-        device_type, device_ip, device_id, device_key, token
-    ) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key, token) as api:
         printer.pprint(
             asdict(
                 await api.stop_shutter(index),
@@ -651,9 +643,7 @@ async def set_shutter_position(
     token: Union[str, None] = None,
 ) -> None:
     """Use to set the shutter position."""
-    async with SwitcherType2Api(
-        device_type, device_ip, device_id, device_key, token
-    ) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key, token) as api:
         printer.pprint(
             asdict(
                 await api.set_position(position, index),
@@ -672,9 +662,7 @@ async def get_light_state(
     token: Union[str, None] = None,
 ) -> None:
     """Use to launch a get_light_state request."""
-    async with SwitcherType2Api(
-        device_type, device_ip, device_id, device_key, token
-    ) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key, token) as api:
         printer.pprint(asdict(await api.get_light_state(index), verbose))
 
 
@@ -688,9 +676,7 @@ async def turn_on_light(
     token: Union[str, None] = None,
 ) -> None:
     """Use for turn on light."""
-    async with SwitcherType2Api(
-        device_type, device_ip, device_id, device_key, token
-    ) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key, token) as api:
         printer.pprint(asdict(await api.set_light(DeviceState.ON, index), verbose))
 
 
@@ -704,9 +690,7 @@ async def turn_off_light(
     token: Union[str, None] = None,
 ) -> None:
     """Use for turn off light."""
-    async with SwitcherType2Api(
-        device_type, device_ip, device_id, device_key, token
-    ) as api:
+    async with SwitcherApi(device_type, device_ip, device_id, device_key, token) as api:
         printer.pprint(asdict(await api.set_light(DeviceState.OFF, index), verbose))
 
 

--- a/src/aioswitcher/api/__init__.py
+++ b/src/aioswitcher/api/__init__.py
@@ -24,7 +24,6 @@ from types import TracebackType
 from typing import Optional, Set, Tuple, Type, Union, final
 
 from ..device import (
-    DeviceCategory,
     DeviceState,
     DeviceType,
     ThermostatFanLevel,
@@ -63,16 +62,6 @@ SWITCHER_TCP_PORT_TYPE1 = 9957
 # Type 2 devices: Breeze, Runners
 SWITCHER_TCP_PORT_TYPE2 = 10000
 
-SWITCHER_DEVICE_TO_TCP_PORT = {
-    DeviceCategory.THERMOSTAT: SWITCHER_TCP_PORT_TYPE2,
-    DeviceCategory.SHUTTER: SWITCHER_TCP_PORT_TYPE2,
-    DeviceCategory.SINGLE_SHUTTER_DUAL_LIGHT: SWITCHER_TCP_PORT_TYPE2,
-    DeviceCategory.DUAL_SHUTTER_SINGLE_LIGHT: SWITCHER_TCP_PORT_TYPE2,
-    DeviceCategory.LIGHT: SWITCHER_TCP_PORT_TYPE2,
-    DeviceCategory.WATER_HEATER: SWITCHER_TCP_PORT_TYPE1,
-    DeviceCategory.POWER_PLUG: SWITCHER_TCP_PORT_TYPE1,
-}
-
 
 @unique
 class Command(Enum):
@@ -91,7 +80,6 @@ class SwitcherApi:
         ip_address: the ip address assigned to the device.
         device_id: the id of the desired device.
         device_key: the login key of the device.
-        port: the port of the device, default is 9957.
 
     """
 
@@ -108,9 +96,8 @@ class SwitcherApi:
         self._ip_address = ip_address
         self._device_id = device_id
         self._device_key = device_key
-        if self._device_type.protocol_type == 1:
-            self._port = SWITCHER_TCP_PORT_TYPE1
-        else:
+        self._port = SWITCHER_TCP_PORT_TYPE1
+        if device_type.protocol_type == 2:
             self._port = SWITCHER_TCP_PORT_TYPE2
         self._connected = False
         self._token = None


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->
## Description

BREAKING CHANGE: Convert SwitcherType1Api and SwitcherType2Api to a single SwitcherApi class.

**Related issue (if any):** fixes #778 

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.
