### PR TITLE
chore: bump min py to 3.12 and publish py to 3.13

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,7 +7,7 @@ on:
     types: [published]
 
 env:
-  MAIN_PY_VER: "3.10"
+  MAIN_PY_VER: "3.13"
 
 jobs:
   deploy-pages:
@@ -36,18 +36,17 @@ jobs:
           pip install -r requirements.txt
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project true
-          poetry lock --no-update
 
       - name: Cache poetry virtual environment
         uses: actions/cache@v4
         with:
           path: .venv
-          # yamllint disable-line rule:line-length
-          key: ${{ runner.os }}-poetry-docs-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}
 
       - name: Build documentation site
         run: |
-          poetry install --no-interaction --without dev
+          poetry lock --no-update
+          poetry install --no-interaction
           poetry run poe docs_build
 
       - name: Deploy to GH-Pages

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
       - dev
 
 env:
-  MAIN_PY_VER: "3.10"
+  MAIN_PY_VER: "3.13"
 
 jobs:
   lint:
@@ -35,7 +35,6 @@ jobs:
           pip install -r requirements.txt
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project true
-          poetry lock --no-update
 
       - name: Cache poetry virtual environment
         uses: actions/cache@v4
@@ -45,6 +44,7 @@ jobs:
 
       - name: Lint the project
         run: |
+          poetry lock --no-update
           poetry install --no-interaction
           poetry run poe lint
 
@@ -53,7 +53,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        python: ["3.9", "3.10"]
+        python: ["3.12", "3.13"]
     name: Test project with Python ${{ matrix.python }}
     permissions:
       checks: write
@@ -83,17 +83,17 @@ jobs:
           pip install -r requirements.txt
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project true
-          poetry lock --no-update
 
       - name: Cache poetry virtual environment
         uses: actions/cache@v4
         with:
           path: .venv
-          # yamllint disable-line rule:line-length
-          key: ${{ runner.os }}-poetry-test-${{ hashFiles('**/pyproject.toml') }}-${{ matrix.python }}
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ matrix.python }}
 
       - name: Install project build dependencies
-        run: poetry install --no-interaction
+        run: |
+          poetry lock --no-update
+          poetry install --no-interaction
 
       - name: Test the project
         run: >
@@ -142,16 +142,15 @@ jobs:
           pip install -r requirements.txt
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project true
-          poetry lock --no-update
 
       - name: Cache poetry virtual environment
         uses: actions/cache@v4
         with:
           path: .venv
-          # yamllint disable-line rule:line-length
-          key: ${{ runner.os }}-poetry-docs-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}
 
       - name: Build documentation site
         run: |
+          poetry lock --no-update
           poetry install --no-interaction
           poetry run poe docs_build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
         required: true
 
 env:
-  MAIN_PY_VER: "3.10"
+  MAIN_PY_VER: "3.13"
 
 jobs:
   release:
@@ -43,14 +43,12 @@ jobs:
           pip install -r requirements.txt
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project true
-          poetry lock --no-update
 
       - name: Cache poetry virtual environment
         uses: actions/cache@v4
         with:
           path: .venv
-          # yamllint disable-line rule:line-length
-          key: ${{ runner.os }}-poetry-release-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}
 
       - name: Configure git
         run: |
@@ -82,7 +80,8 @@ jobs:
 
       - name: Verify documentation site build
         run: |
-          poetry install --no-interaction --without dev
+          poetry lock --no-update
+          poetry install --no-interaction
           poetry run poe docs_build
 
       - name: Publish build to PyPi

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -8,11 +8,12 @@ on:
       - dev
     paths:
       - src/**
+      - tests/**
       - pyproject.toml
       - requirements.txt
 
 env:
-  MAIN_PY_VER: "3.10"
+  MAIN_PY_VER: "3.13"
 
 jobs:
   test:
@@ -44,17 +45,16 @@ jobs:
           pip install -r requirements.txt
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project true
-          poetry lock --no-update
 
       - name: Cache poetry virtual environment
         uses: actions/cache@v4
         with:
           path: .venv
-          # yamllint disable-line rule:line-length
-          key: ${{ runner.os }}-poetry-test-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}
 
       - name: Install, test with coverage report, and build
         run: |
+          poetry lock --no-update
           poetry install --no-interaction
           poetry run poe test_rep
           poetry build

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,5 @@
 ---
-name: 'Close stale issues and PRs'
+name: 'Close stale issues'
 on:
   schedule:
     - cron: '0 2 * * *'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ include = [ ]
 exclude = [ ]
 
   [tool.poetry.dependencies]
-  python = "^3.9.0"
+  python = "^3.12.0"
   pycryptodome = ">=3.18.0"
   aiohttp = ">=3.10.3"
 

--- a/tests/test_device_tools.py
+++ b/tests/test_device_tools.py
@@ -46,7 +46,7 @@ def test_minutes_to_hexadecimal_seconds_with_correct_minutes_should_return_expec
 def test_minutes_to_hexadecimal_seconds_with_a_negative_value_should_throw_an_error():
     assert_that(tools.minutes_to_hexadecimal_seconds).raises(
         Exception
-    ).when_called_with(-1).is_equal_to("argument out of range")
+    ).when_called_with(-1).is_equal_to("'I' format requires 0 <= number <= 4294967295")
 
 
 def test_timedelta_to_hexadecimal_seconds_with_an_allowed_timedelta_should_return_an_hex_timestamp():
@@ -90,7 +90,7 @@ def test_current_timestamp_to_hexadecimal_should_return_the_current_timestamp():
 def test_current_timestamp_to_hexadecimal_with_errornous_value_should_throw_an_error(_):
     assert_that(tools.current_timestamp_to_hexadecimal).raises(
         Exception
-    ).when_called_with().is_equal_to("argument out of range")
+    ).when_called_with().is_equal_to("'I' format requires 0 <= number <= 4294967295")
 
 
 @mark.parametrize("watts, amps", [(1608, 7.3), (2600, 11.8), (3489, 15.9)])


### PR DESCRIPTION
## Description

<!-- Describe what you did and why. -->

BREAKING CHANGE: The minimum Python requirement is now 3.12.

This commit also includes a couple of adjustments to the cached environments in the CI.

fixes: #818

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

<!-- Anything else? -->
