### PR TITLE
fix: cleared multiple deperecation notices

### DIFF
--- a/src/aioswitcher/device/tools.py
+++ b/src/aioswitcher/device/tools.py
@@ -174,7 +174,7 @@ async def validate_token(username: str, token: str) -> bool:
     request_data = {"email": username, "token": token}
     is_token_valid = False
     # Preload the SSL context
-    ssl_context = ssl.SSLContext()
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 
     logger.debug("calling API call for Switcher to validate the token")
 

--- a/src/aioswitcher/schedule/tools.py
+++ b/src/aioswitcher/schedule/tools.py
@@ -16,7 +16,7 @@
 
 import time
 from binascii import hexlify
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from struct import pack
 from typing import Set, Union
 
@@ -38,7 +38,7 @@ def pretty_next_run(start_time: str, days: Set[Days] = set()) -> str:
     if not days:
         return f"Due today at {start_time}"
 
-    current_datetime = datetime.utcnow()
+    current_datetime = datetime.now(UTC)
     current_weekday = current_datetime.weekday()
 
     current_time = datetime.strptime(

--- a/tests/test_schedule_tools.py
+++ b/tests/test_schedule_tools.py
@@ -15,7 +15,7 @@
 """Switcher integration pretty next run tool test cases."""
 
 from binascii import hexlify, unhexlify
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from struct import pack, unpack
 
 import time_machine
@@ -30,7 +30,7 @@ days_by_weekdays = dict(map(lambda d: (d.weekday, d), Days))
 
 @fixture()
 def today():
-    return datetime.utcnow()
+    return datetime.now(UTC)
 
 
 @fixture


### PR DESCRIPTION
## Description
<!-- Describe what you did and why. -->

When I ran some tests, I noticed a couple of deprecation notices:
- For `datetime.datetime.utcnow()`, the resolution is specified in the deprecation notice: `datetime.datetime.now(datetime.UTC)`.
- For `ssl.SSLContext()`, since version 3.10, [SSLContext](https://docs.python.org/3.10/library/ssl.html#ssl.SSLContext), the default value for the SSLContext function, [PROTOCOL_TLS](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS), was deprecated in favour of  [PROTOCOL_TLS_CLIENT](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS_CLIENT) and [PROTOCOL_TLS_SERVER](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS_SERVER).

![image](https://github.com/user-attachments/assets/eaefa891-9de2-48f7-b9a9-c599b98dffbe)

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

<!-- Anything else? -->
![image](https://github.com/user-attachments/assets/114597f3-15b6-49b7-a5ef-70a721951888)
