### PR TITLE
chore: remove bridge broadcast ports and udp port mappings

### DIFF
--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -638,7 +638,7 @@ Use to discover devices and their states.
 ```shell title="scripts/discover_devices.py"
 $ poetry run discover_devices --help
 
-usage: discover_devices.py [-h] [-t {1,2,all}] [delay]
+usage: discover_devices.py [-h] [delay]
 
 Discover and print info of Switcher devices
 
@@ -647,17 +647,10 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  -t {1,2,all}, --type {1,2,all}
-                        set protocol type: ['1', '2', 'all']
 
 Executing this script will print a serialized version of the discovered Switcher
 devices broadcasting on the local network for 60 seconds.
 You can change the delay by passing an int argument: discover_devices.py 30
-
-Switcher devices uses two protocol types:
-    Protocol type 1 (UDP port 20002 or port 10002), used by: Switcher Mini, Switcher Power Plug, Switcher Touch, Switcher V2 (esp), Switcher V2 (qualcomm), Switcher V4
-    Protocol type 2 (UDP port 20003 or port 10003), used by: Switcher Breeze, Switcher Runner, Switcher Runner Mini, Switcher Runner S11, Switcher Runner S12, Switcher Light SL01, Switcher Light SL01 Mini, Switcher Light SL02, Switcher Light SL02 Mini, Switcher Light SL03
-You can change the scanned protocol type by passing an int argument: discover_devices.py -t 1
 
 Note:
     WILL PRINT PRIVATE INFO SUCH AS DEVICE ID AND MAC.
@@ -679,14 +672,8 @@ Example output:
             'power_consumption': 0,
             'remaining_time': '00:00:00'}
     ```
-Print all protocol types devices for 30 seconds:
-    python discover_devices.py 30 -t all
-
-Print only protocol type 1 devices:
-    python discover_devices.py -t 1
-
-Print only protocol type 2 devices:
-    python discover_devices.py -t 2
+Print devices for 30 seconds:
+    python discover_devices.py 30
 ```
 ``
 ## Get device login key


### PR DESCRIPTION
## Description
<!-- Describe what you did and why. -->

BREAKING CHANGE: [broadcast_ports](https://github.com/TomerFi/aioswitcher/blob/dev/src/aioswitcher/bridge.py#L382) parameter is removed from the bridge

1. Remove the argument for [broadcast_ports](https://github.com/TomerFi/aioswitcher/blob/dev/src/aioswitcher/bridge.py#L382).
2. Remove the unused [device to udp port mapping](https://github.com/TomerFi/aioswitcher/blob/dev/src/aioswitcher/bridge.py#L64C1-L72).
3. Update the docs and discover device script to match the changes

fixes #817 
## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information
<!-- Anything else? -->
