### PR TITLE
fix: add scripts path instructions to CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -18,6 +18,12 @@ reviews:
         - Proper use of pytest fixtures and async test patterns
         - Adequate test coverage and edge case handling
         - Clear test naming and organization
+    - path: scripts/**/*.py
+      instructions: |
+        Review utility scripts for:
+        - Clear CLI argument handling
+        - Proper error handling and user feedback
+        - Consistent logging and output formatting
   tools:
     ruff:
       enabled: true


### PR DESCRIPTION
## Summary

Add missing `path_instructions` for `scripts/**/*.py` in CodeRabbit configuration.

## Changes

- Add review instructions for utility scripts covering:
  - CLI argument handling
  - Error handling and user feedback
  - Logging and output formatting

## Why

The original config only had instructions for `src/` and `tests/`, missing the `scripts/` folder which contains 4 Python utility scripts.

## Summary by Sourcery

Enhancements:
- Extend CodeRabbit review configuration to cover Python scripts under scripts/** with script-specific review criteria.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review configuration for utility scripts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->