### PR TITLE
chore: use github-actions[bot] identity and SSH signing

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,9 +1,6 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 ---
 reviews:
-  profile: chill
-  collapse_walkthrough: false
-  sequence_diagrams: true
   path_instructions:
     - path: src/**/*.py
       instructions: |
@@ -24,8 +21,3 @@ reviews:
         - Clear CLI argument handling
         - Proper error handling and user feedback
         - Consistent logging and output formatting
-  tools:
-    ruff:
-      enabled: true
-    yamllint:
-      enabled: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,17 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup SSH signing
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SIGNING_KEY }}" > ~/.ssh/signing_key
+          chmod 600 ~/.ssh/signing_key
+          git config gpg.format ssh
+          git config user.signingkey ~/.ssh/signing_key
+          git config commit.gpgsign true
 
       - name: Determine version and create changelog
         id: bumper

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Setup SSH signing
         run: |
           mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
           echo "${{ secrets.SIGNING_KEY }}" > ~/.ssh/signing_key
           chmod 600 ~/.ssh/signing_key
           git config gpg.format ssh
@@ -133,3 +134,7 @@ jobs:
               generate_release_notes: true
             })
             core.setOutput('html_url', response.data.html_url)
+
+      - name: Cleanup SSH signing key
+        if: always()
+        run: rm -f ~/.ssh/signing_key


### PR DESCRIPTION
## Summary

- Use `github-actions[bot]` identity for release commits instead of `github.actor`
- Add SSH commit signing using `SIGNING_KEY` secret

## Changes

- Updated git config to use bot identity (ID 41898282)
- Added SSH signing setup step

## Prerequisites

Ensure `SIGNING_KEY` secret is configured in the `deployment` environment.

## Summary by Sourcery

Configure release workflow to use the GitHub Actions bot identity with SSH-signed release commits.

CI:
- Update release workflow to commit using the github-actions[bot] account instead of the triggering actor.
- Add SSH-based commit signing in the release workflow using a signing key secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release workflow: changed commit attribution identity.
  * Added SSH-based commit signing setup and a cleanup step to remove signing keys after runs.
  * Cleaned CI/configuration: removed several review-related settings and an external tools block, relying on remaining defaults.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->