### PR TITLE
fix: remove custom SSL context from validate_token

### DIFF
--- a/src/aioswitcher/device/tools.py
+++ b/src/aioswitcher/device/tools.py
@@ -15,7 +15,6 @@
 """Switcher integration device module tools."""
 
 import datetime
-import ssl
 import time
 from base64 import b64decode
 from binascii import crc_hqx, hexlify, unhexlify
@@ -173,15 +172,11 @@ async def validate_token(username: str, token: str) -> bool:
     request_url = "https://switcher.co.il/ValidateToken/"
     request_data = {"email": username, "token": token}
     is_token_valid = False
-    # Preload the SSL context
-    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 
     logger.debug("calling API call for Switcher to validate the token")
 
     async with aiohttp.ClientSession() as session:
-        async with session.post(
-            request_url, data=request_data, ssl=ssl_context
-        ) as response:
+        async with session.post(request_url, data=request_data) as response:
             if response.status == 200:
                 logger.debug("request successful")
                 try:


### PR DESCRIPTION
## Summary

- Remove the custom `SSLContext` from `validate_token()` and let aiohttp use its default SSL handling.
- The custom context was created with `PROTOCOL_TLS_CLIENT` (enabling certificate verification) but without loading any CA certificates, causing all TLS handshakes to fail with `CERTIFICATE_VERIFY_FAILED`.
- The `ssl` import is also removed as it is no longer used.

## Why this works

aiohttp's `ssl` parameter on request methods [defaults to `True`](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientSession.request), which is documented as:

> `ssl` – SSL validation mode. `True` for default SSL check (`ssl.create_default_context()` is used), `False` for skip SSL certificate validation, `aiohttp.Fingerprint` for fingerprint validation, `ssl.SSLContext` for custom SSL certificate validation.

By not passing `ssl=` at all (defaulting to `True`), aiohttp internally calls `ssl.create_default_context()`, which loads system CA certificates and enables proper verification — exactly the correct behavior.

Fixes #856