### PR TITLE
fix: set SO_REUSEADDR on the broadcast listener socket

### DIFF
--- a/src/aioswitcher/bridge.py
+++ b/src/aioswitcher/bridge.py
@@ -19,7 +19,14 @@ from binascii import hexlify
 from dataclasses import dataclass
 from functools import partial
 from logging import getLogger
-from socket import AF_INET, inet_ntoa
+from socket import (
+    AF_INET,
+    SO_REUSEADDR,
+    SOCK_DGRAM,
+    SOL_SOCKET,
+    inet_ntoa,
+    socket,
+)
 from struct import error as struct_error
 from struct import pack
 from types import TracebackType
@@ -428,10 +435,17 @@ class SwitcherBridge:
             protocol_factory = UdpClientProtocol(
                 partial(_parse_device_from_datagram, self._on_device)
             )
+            # Bind with SO_REUSEADDR so a reload can rebind the port while the
+            # previous socket is still lingering in TIME_WAIT, instead of failing
+            # with "address already in use" (errno 98) until a full restart. This
+            # follows the same pattern aioshelly uses for its CoAP listener.
+            sock = socket(AF_INET, SOCK_DGRAM)
+            sock.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
+            sock.setblocking(False)
+            sock.bind(("0.0.0.0", broadcast_port))  # nosec
             transport, protocol = await get_running_loop().create_datagram_endpoint(
                 lambda: protocol_factory,
-                local_addr=("0.0.0.0", broadcast_port),  # nosec
-                family=AF_INET,
+                sock=sock,
             )
             self._transports[broadcast_port] = transport
             logger.debug("udp bridge on port %s started", broadcast_port)

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -101,3 +101,11 @@ async def test_malformed_datagram_is_skipped_and_logged(mock_debug):
     logged_args = mock_debug.call_args.args
     assert_that(logged_args).contains(addr)
     assert_that(logged_args).contains(data.hex())
+
+
+async def test_bridge_listener_socket_has_reuseaddr(unused_udp_broadcast_port, mock_callback):
+    port = unused_udp_broadcast_port
+    async with SwitcherBridge(mock_callback) as bridge:
+        sock = bridge._transports[port].get_extra_info("socket")
+        reuseaddr = sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR)
+        assert_that(reuseaddr).is_not_zero()


### PR DESCRIPTION
## Problem

The UDP bridge can fail to restart with `OSError: [Errno 98] Address already in use`. Downstream in the Home Assistant `switcher_kis` integration this shows up as devices going unavailable and the integration wedging on reload until a full Home Assistant restart: when the entry reloads, the previous listener socket is still lingering in `TIME_WAIT`, so rebinding the same broadcast port fails.

## The fix

Create each broadcast listener socket manually with `SO_REUSEADDR` set before `bind`, then hand it to `create_datagram_endpoint` via `sock=`, so a reload can rebind the port immediately:

```python
sock = socket(AF_INET, SOCK_DGRAM)
sock.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
sock.setblocking(False)
sock.bind(("0.0.0.0", broadcast_port))
transport, protocol = await get_running_loop().create_datagram_endpoint(
    lambda: protocol_factory, sock=sock,
)
```

This follows the same pattern aioshelly uses for its CoAP listener socket: https://github.com/home-assistant-libs/aioshelly/blob/master/aioshelly/block_device/coap.py

## Test

Adds one focused test asserting the created listener socket has `SO_REUSEADDR` set.

Gates pass locally: `poetry run poe test` (306 passed) and `poetry run poe lint` (black, flake8, isort, mypy strict, yamllint), coverage 99.05 percent.

## Scope

Reduced per review to just the `SO_REUSEADDR` change. The datagram parse guard that was previously bundled here is split out into #890.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UDP bridge startup and socket handling for more reliable listener initialization.
  * Enabled address reuse to help prevent binding conflicts when restarting the bridge.

* **Tests**
  * Added coverage verifying that listener sockets allow address reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->