### PR TITLE
ci: harden workflows with SHA pinning, permissions, concurrency, and OIDC

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
 env:
   MAIN_PY_VER: "3.13"
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,17 +16,17 @@ jobs:
     name: Build documentation site and deploy to GH-Pages
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v7
+        uses: 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: 5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ env.MAIN_PY_VER }}
 
       - name: Cache pip repository
-        uses: actions/cache@v6
+        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ env.MAIN_PY_VER }}
@@ -38,7 +38,7 @@ jobs:
           poetry config virtualenvs.in-project true
 
       - name: Cache poetry virtual environment
-        uses: actions/cache@v6
+        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .venv
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}
@@ -50,7 +50,7 @@ jobs:
           poetry run poe docs_build
 
       - name: Deploy to GH-Pages
-        uses: peaceiris/actions-gh-pages@v4.1.0
+        uses: 1ef5a1b1df4c63fe21a2242edbee6cac921ece01  # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,6 +19,7 @@ jobs:
         uses: 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
 
       - name: Set up Python
         uses: 5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,7 +7,7 @@ on:
     types: [published]
 
 concurrency:
-  group: ${{workflow}}-${{github.ref}}
+  group: ${{ github.workflow }}-${{github.ref}}
   cancel-in-progress: true
 
 env:
@@ -23,18 +23,18 @@ jobs:
     name: Build documentation site and deploy to GH-Pages
     steps:
       - name: Checkout sources
-        uses: 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ github.ref }}
           persist-credentials: false
 
       - name: Set up Python
-        uses: 5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ env.MAIN_PY_VER }}
 
       - name: Cache pip repository
-        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ env.MAIN_PY_VER }}
@@ -46,7 +46,7 @@ jobs:
           poetry config virtualenvs.in-project true
 
       - name: Cache poetry virtual environment
-        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .venv
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}
@@ -58,7 +58,7 @@ jobs:
           poetry run poe docs_build
 
       - name: Deploy to GH-Pages
-        uses: 1ef5a1b1df4c63fe21a2242edbee6cac921ece01  # v4.1.0
+        uses: peaceiris/actions-gh-pages@1ef5a1b1df4c63fe21a2242edbee6cac921ece01  # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,9 @@ jobs:
   deploy-pages:
     runs-on: ubuntu-latest
     environment: github-pages
+    permissions:
+      pages: write
+      contents: write
     name: Build documentation site and deploy to GH-Pages
     steps:
       - name: Checkout sources

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -110,6 +110,7 @@ jobs:
           else poetry run poe test; fi
 
       - name: Report test summary
+        # yamllint disable-line rule:line-length
         uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3  # v2.24.0
         if: ${{ matrix.python == env.MAIN_PY_VER && always() }}
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
       - dev
 
 concurrency:
-  group: ${{workflow}}-${{github.ref}}-${{github.event.number}}
+  group: ${{ github.workflow }}-${{github.ref}}-${{github.event.number}}
   cancel-in-progress: true
 
 env:
@@ -21,17 +21,17 @@ jobs:
       pull-requests: read
     steps:
       - name: Source checkout
-        uses: 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Python ${{ env.MAIN_PY_VER }}
-        uses: 5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ env.MAIN_PY_VER }}
 
       - name: Cache pip repository
-        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ env.MAIN_PY_VER }}
@@ -43,7 +43,7 @@ jobs:
           poetry config virtualenvs.in-project true
 
       - name: Cache poetry virtual environment
-        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .venv
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}
@@ -66,22 +66,22 @@ jobs:
       pull-requests: write
     steps:
       - name: Source checkout
-        uses: 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup timezone
-        uses: 040202c2ecba2d55edb016acf01bbeb42261dfc0  # v2.0.0
+        uses: zcong1993/setup-timezone@040202c2ecba2d55edb016acf01bbeb42261dfc0  # v2.0.0
         with:
           timezone: Asia/Jerusalem
 
       - name: Set up Python
-        uses: 5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ matrix.python }}
 
       - name: Cache pip repository
-        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ matrix.python }}
@@ -93,7 +93,7 @@ jobs:
           poetry config virtualenvs.in-project true
 
       - name: Cache poetry virtual environment
-        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .venv
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ matrix.python }}
@@ -110,7 +110,7 @@ jobs:
           else poetry run poe test; fi
 
       - name: Report test summary
-        uses: d0a4676d0e0b938bc201470d88276b7c74c712b3  # v2.24.0
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3  # v2.24.0
         if: ${{ matrix.python == env.MAIN_PY_VER && always() }}
         with:
           test_changes_limit: 0
@@ -118,7 +118,7 @@ jobs:
           report_individual_runs: true
 
       - name: Push to CodeCov
-        uses: a99c28d3f0da835de33ff2feb2e15691c7b9641f  # v7.0.0
+        uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f  # v7.0.0
         if: ${{ matrix.python == env.MAIN_PY_VER }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -132,17 +132,17 @@ jobs:
       pull-requests: read
     steps:
       - name: Source checkout
-        uses: 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: 5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ env.MAIN_PY_VER }}
 
       - name: Cache pip repository
-        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ env.MAIN_PY_VER }}
@@ -154,7 +154,7 @@ jobs:
           poetry config virtualenvs.in-project true
 
       - name: Cache poetry virtual environment
-        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .venv
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - dev
 
+concurrency:
+  group: ${{workflow}}-${{github.ref}}-${{github.event.number}}
+  cancel-in-progress: true
+
 env:
   MAIN_PY_VER: "3.13"
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Source checkout
         uses: 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ env.MAIN_PY_VER }}
         uses: 5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
@@ -61,6 +63,8 @@ jobs:
     steps:
       - name: Source checkout
         uses: 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup timezone
         uses: 040202c2ecba2d55edb016acf01bbeb42261dfc0  # v2.0.0
@@ -125,6 +129,8 @@ jobs:
     steps:
       - name: Source checkout
         uses: 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: 5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,15 +17,15 @@ jobs:
       pull-requests: read
     steps:
       - name: Source checkout
-        uses: actions/checkout@v7
+        uses: 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Python ${{ env.MAIN_PY_VER }}
-        uses: actions/setup-python@v7
+        uses: 5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ env.MAIN_PY_VER }}
 
       - name: Cache pip repository
-        uses: actions/cache@v6
+        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ env.MAIN_PY_VER }}
@@ -37,7 +37,7 @@ jobs:
           poetry config virtualenvs.in-project true
 
       - name: Cache poetry virtual environment
-        uses: actions/cache@v6
+        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .venv
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}
@@ -60,20 +60,20 @@ jobs:
       pull-requests: write
     steps:
       - name: Source checkout
-        uses: actions/checkout@v7
+        uses: 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup timezone
-        uses: zcong1993/setup-timezone@v2.0.0
+        uses: 040202c2ecba2d55edb016acf01bbeb42261dfc0  # v2.0.0
         with:
           timezone: Asia/Jerusalem
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: 5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ matrix.python }}
 
       - name: Cache pip repository
-        uses: actions/cache@v6
+        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ matrix.python }}
@@ -85,7 +85,7 @@ jobs:
           poetry config virtualenvs.in-project true
 
       - name: Cache poetry virtual environment
-        uses: actions/cache@v6
+        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .venv
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ matrix.python }}
@@ -102,7 +102,7 @@ jobs:
           else poetry run poe test; fi
 
       - name: Report test summary
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: d0a4676d0e0b938bc201470d88276b7c74c712b3  # v2.24.0
         if: ${{ matrix.python == env.MAIN_PY_VER && always() }}
         with:
           test_changes_limit: 0
@@ -110,7 +110,7 @@ jobs:
           report_individual_runs: true
 
       - name: Push to CodeCov
-        uses: codecov/codecov-action@v7
+        uses: a99c28d3f0da835de33ff2feb2e15691c7b9641f  # v7.0.0
         if: ${{ matrix.python == env.MAIN_PY_VER }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -124,15 +124,15 @@ jobs:
       pull-requests: read
     steps:
       - name: Source checkout
-        uses: actions/checkout@v7
+        uses: 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: 5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ env.MAIN_PY_VER }}
 
       - name: Cache pip repository
-        uses: actions/cache@v6
+        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ env.MAIN_PY_VER }}
@@ -144,7 +144,7 @@ jobs:
           poetry config virtualenvs.in-project true
 
       - name: Cache poetry virtual environment
-        uses: actions/cache@v6
+        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .venv
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ on:
           - patch
           - auto
 
+concurrency:
+  group: ${{workflow}}-${{github.ref}}
+  cancel-in-progress: false
+
 env:
   MAIN_PY_VER: "3.13"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
     environment: deployment
     permissions:
       contents: write
+      id-token: write
     name: Build, publish, and release
     steps:
       - name: Checkout sources
@@ -106,7 +107,10 @@ jobs:
       - name: Publish build to PyPi
         run: |
           rm -rf ./dist
-          poetry publish --build --no-interaction -u __token__ -p ${{ secrets.PYPI_TOKEN }}
+          poetry build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@2834a314042ef964da07689278dd1e9d773e8afd  # v1.14.1
 
       - name: Set development project version
         uses: 49b76fb8c351868945711489fd30ba3de29191a5  # 2.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
           - auto
 
 concurrency:
-  group: ${{workflow}}-${{github.ref}}
+  group: ${{ github.workflow }}-${{github.ref}}
   cancel-in-progress: false
 
 env:
@@ -35,18 +35,18 @@ jobs:
     name: Build, publish, and release
     steps:
       - name: Checkout sources
-        uses: 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Setup Python
-        uses: 5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ env.MAIN_PY_VER }}
 
       - name: Cache pip repository
-        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ env.MAIN_PY_VER }}
@@ -58,7 +58,7 @@ jobs:
           poetry config virtualenvs.in-project true
 
       - name: Cache poetry virtual environment
-        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .venv
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}
@@ -70,21 +70,21 @@ jobs:
 
       - name: Setup SSH signing
         run: |
-          mkdir -p $RUNNER_TEMP
-          echo "${{ secrets.SIGNING_KEY }}" > $RUNNER_TEMP/signing_key
-          chmod 600 $RUNNER_TEMP/signing_key
+          mkdir -p "$RUNNER_TEMP"
+          echo "${{ secrets.SIGNING_KEY }}" > "$RUNNER_TEMP/signing_key"
+          chmod 600 "$RUNNER_TEMP/signing_key"
           git config gpg.format ssh
-          git config user.signingkey $RUNNER_TEMP/signing_key
+          git config user.signingkey "$RUNNER_TEMP/signing_key"
           git config commit.gpgsign true
 
       - name: Determine version and create changelog
         id: bumper
-        uses: 2d160ea4d1b4e1bc5534c9eece726a1227b19afd  # 2.0.9
+        uses: tomerfi/version-bumper-action@2d160ea4d1b4e1bc5534c9eece726a1227b19afd  # 2.0.9
         with:
           bump: '${{ github.event.inputs.bump }}'
 
       - name: Set new project version
-        uses: 49b76fb8c351868945711489fd30ba3de29191a5  # 2.0.0
+        uses: sandstromviktor/toml-editor@49b76fb8c351868945711489fd30ba3de29191a5  # 2.0.0
         with:
           file: pyproject.toml
           key: project.version
@@ -113,7 +113,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@2834a314042ef964da07689278dd1e9d773e8afd  # v1.14.1
 
       - name: Set development project version
-        uses: 49b76fb8c351868945711489fd30ba3de29191a5  # 2.0.0
+        uses: sandstromviktor/toml-editor@49b76fb8c351868945711489fd30ba3de29191a5  # 2.0.0
         with:
           file: pyproject.toml
           key: project.version
@@ -127,7 +127,7 @@ jobs:
 
       - name: Create a release name
         id: release_name
-        uses: 373c709c69115d41ff229c7e5df9f8788daa9553  # v9.0.0
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553  # v9.0.0
         with:
           script: |
             var retval = '${{ steps.bumper.outputs.next }}'
@@ -138,7 +138,7 @@ jobs:
 
       - name: Create a release
         id: gh_release
-        uses: 373c709c69115d41ff229c7e5df9f8788daa9553  # v9.0.0
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553  # v9.0.0
         with:
           github-token: ${{ secrets.RELEASE_PAT }}
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment: deployment
+    permissions:
+      contents: write
     name: Build, publish, and release
     steps:
       - name: Checkout sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,18 +22,18 @@ jobs:
     name: Build, publish, and release
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v7
+        uses: 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: 5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ env.MAIN_PY_VER }}
 
       - name: Cache pip repository
-        uses: actions/cache@v6
+        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ env.MAIN_PY_VER }}
@@ -45,7 +45,7 @@ jobs:
           poetry config virtualenvs.in-project true
 
       - name: Cache poetry virtual environment
-        uses: actions/cache@v6
+        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .venv
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}
@@ -67,12 +67,12 @@ jobs:
 
       - name: Determine version and create changelog
         id: bumper
-        uses: tomerfi/version-bumper-action@2.0.9
+        uses: 2d160ea4d1b4e1bc5534c9eece726a1227b19afd  # 2.0.9
         with:
           bump: '${{ github.event.inputs.bump }}'
 
       - name: Set new project version
-        uses: sandstromviktor/toml-editor@2.0.0
+        uses: 49b76fb8c351868945711489fd30ba3de29191a5  # 2.0.0
         with:
           file: pyproject.toml
           key: project.version
@@ -98,7 +98,7 @@ jobs:
           poetry publish --build --no-interaction -u __token__ -p ${{ secrets.PYPI_TOKEN }}
 
       - name: Set development project version
-        uses: sandstromviktor/toml-editor@2.0.0
+        uses: 49b76fb8c351868945711489fd30ba3de29191a5  # 2.0.0
         with:
           file: pyproject.toml
           key: project.version
@@ -112,7 +112,7 @@ jobs:
 
       - name: Create a release name
         id: release_name
-        uses: actions/github-script@v9
+        uses: 373c709c69115d41ff229c7e5df9f8788daa9553  # v9.0.0
         with:
           script: |
             var retval = '${{ steps.bumper.outputs.next }}'
@@ -123,7 +123,7 @@ jobs:
 
       - name: Create a release
         id: gh_release
-        uses: actions/github-script@v9
+        uses: 373c709c69115d41ff229c7e5df9f8788daa9553  # v9.0.0
         with:
           github-token: ${{ secrets.RELEASE_PAT }}
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,12 @@ on:
         description: "Bump type (major/minor/patch) defaults to auto"
         default: "auto"
         required: true
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+          - auto
 
 env:
   MAIN_PY_VER: "3.13"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,12 +67,11 @@ jobs:
 
       - name: Setup SSH signing
         run: |
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-          echo "${{ secrets.SIGNING_KEY }}" > ~/.ssh/signing_key
-          chmod 600 ~/.ssh/signing_key
+          mkdir -p $RUNNER_TEMP
+          echo "${{ secrets.SIGNING_KEY }}" > $RUNNER_TEMP/signing_key
+          chmod 600 $RUNNER_TEMP/signing_key
           git config gpg.format ssh
-          git config user.signingkey ~/.ssh/signing_key
+          git config user.signingkey $RUNNER_TEMP/signing_key
           git config commit.gpgsign true
 
       - name: Determine version and create changelog
@@ -144,7 +143,3 @@ jobs:
               generate_release_notes: true
             })
             core.setOutput('html_url', response.data.html_url)
-
-      - name: Cleanup SSH signing key
-        if: always()
-        run: rm -f ~/.ssh/signing_key

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -22,20 +22,20 @@ jobs:
     name: Stage project
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v7
+        uses: 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup timezone
-        uses: zcong1993/setup-timezone@v2.0.0
+        uses: 040202c2ecba2d55edb016acf01bbeb42261dfc0  # v2.0.0
         with:
           timezone: Asia/Jerusalem
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: 5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ env.MAIN_PY_VER }}
 
       - name: Cache pip repository
-        uses: actions/cache@v6
+        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ env.MAIN_PY_VER }}
@@ -47,7 +47,7 @@ jobs:
           poetry config virtualenvs.in-project true
 
       - name: Cache poetry virtual environment
-        uses: actions/cache@v6
+        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .venv
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}
@@ -60,7 +60,7 @@ jobs:
           poetry build
 
       - name: Push to CodeCov
-        uses: codecov/codecov-action@v7
+        uses: a99c28d3f0da835de33ff2feb2e15691c7b9641f  # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -12,6 +12,10 @@ on:
       - pyproject.toml
       - requirements.txt
 
+concurrency:
+  group: ${{workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
 env:
   MAIN_PY_VER: "3.13"
 

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -23,6 +23,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     environment: staging
+    permissions:
+      contents: read
     name: Stage project
     steps:
       - name: Checkout sources

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup timezone
         uses: 040202c2ecba2d55edb016acf01bbeb42261dfc0  # v2.0.0

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -13,7 +13,7 @@ on:
       - requirements.txt
 
 concurrency:
-  group: ${{workflow}}-${{github.ref}}
+  group: ${{ github.workflow }}-${{github.ref}}
   cancel-in-progress: true
 
 env:
@@ -28,22 +28,22 @@ jobs:
     name: Stage project
     steps:
       - name: Checkout sources
-        uses: 3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup timezone
-        uses: 040202c2ecba2d55edb016acf01bbeb42261dfc0  # v2.0.0
+        uses: zcong1993/setup-timezone@040202c2ecba2d55edb016acf01bbeb42261dfc0  # v2.0.0
         with:
           timezone: Asia/Jerusalem
 
       - name: Set up Python
-        uses: 5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ env.MAIN_PY_VER }}
 
       - name: Cache pip repository
-        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ env.MAIN_PY_VER }}
@@ -55,7 +55,7 @@ jobs:
           poetry config virtualenvs.in-project true
 
       - name: Cache poetry virtual environment
-        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .venv
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ env.MAIN_PY_VER }}
@@ -68,7 +68,7 @@ jobs:
           poetry build
 
       - name: Push to CodeCov
-        uses: a99c28d3f0da835de33ff2feb2e15691c7b9641f  # v7.0.0
+        uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f  # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml


### PR DESCRIPTION
This PR hardens CI workflows across all 4 workflow files (pr, stage, release, pages) with supply-chain security, least-privilege permissions, and best practices.

## Changes

**1. Pin actions to SHA digests** — All `uses:` now use the commit SHA instead of a mutable tag, in the `{owner}/{repo}@{sha}` format. The semantic version is preserved as a trailing comment (e.g., `# v7.0.1`). Covers 10 actions across 34 references.

**2. Add `persist-credentials: false` to checkout steps** — Prevents GITHUB_TOKEN from being misused. Added to all 6 checkout steps (excluded from release.yml which uses SSH deploy key).

**3. Add concurrency blocks** — Cancels stale runs:
- pr.yml: per-PR cancellation (`${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}`)
- stage.yml & pages.yml: per-branch cancellation
- release.yml: no cancellation (manual dispatch, concurrent releases allowed)

**4. Move SSH signing key to `$RUNNER_TEMP`** — Uses ephemeral runner storage instead of `~/.ssh`. Removes unnecessary cleanup step since runner temp is wiped automatically.

**5. Add per-job permissions blocks** — pr.yml already had these. Added to:
- pages.yml: `pages: write`, `contents: write` (gh-pages deploy)
- stage.yml: `contents: read` (checkout)
- release.yml: `contents: write` (git push + release creation)

**6. Switch PyPI publishing to OIDC trusted publishing** — Replaced `poetry publish -p $PYPI_TOKEN` with `pypa/gh-action-pypi-publish`. No more long-lived API token — uses short-lived OIDC tokens instead. Added `id-token: write` permission. Requires linking the workflow in PyPI project settings (already done).

Fixes: #896

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability and security of automated builds, tests, documentation checks, deployments, and releases.
  * Prevented outdated workflow runs from continuing when newer runs are triggered.
  * Strengthened release publishing and commit-signing safeguards.
  * Standardized automated test reporting and timezone handling for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->