### PR TITLE
docs: added ai policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@
 
 aioswitcher is a Python 3.12+ async library for integrating with Switcher smart switches and outlets (power plugs, wall switches, curtain motor controllers, thermostat controllers, water heater controllers). It uses `uv` for dependency management and `pytest` with strict asyncio mode for testing.
 
+## AI Policy
+
+This project has an [AI policy](AI_POLICY.md). Always read it and ensure all suggestions, code, and contributions comply. If any behavior seems to conflict with the policy, warn the user and ask for guidance.
+
 ## Client Projects
 
 aioswitcher is a dependency for two major projects — always consider them when making changes, especially breaking ones.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -10,7 +10,7 @@ The only expectation is this: **verify everything that comes out of your machine
 
 ## Quality Bar
 
-This is a community-driven project built on volunteer time. Wasting a contributor's free time chasing hallucinations, copy-pasted boilerplate, or obvious AI slop is unacceptable and will be called out.
+This is a community-driven project built on volunteer time. Wasting contributors' free time chasing hallucinations, copy-pasted boilerplate, or obvious AI slop is unacceptable and will be called out.
 
 Do not make autonomous contributions or file autonomous issues. Submit only what you have reviewed and stand behind.
 

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,22 @@
+# AI Policy
+
+## Usage Encouraged
+
+AI tools are encouraged for any task where they help — grammar, phrasing, coding, reviews, testing, linting, documentation, or anything else. You are **not required to disclose your use of AI tools**. We assume everyone uses them.
+
+## Be Your Own Guardrail
+
+The only expectation is this: **verify everything that comes out of your machine before it leaves it.** You are responsible for everything you contribute. Check it, understand it, own it.
+
+## Quality Bar
+
+This is a community-driven project built on volunteer time. Wasting a contributor's free time chasing hallucinations, copy-pasted boilerplate, or obvious AI slop is unacceptable and will be called out.
+
+Do not make autonomous contributions or file autonomous issues. Submit only what you have reviewed and stand behind.
+
+## In Short
+
+- Use AI however it helps you.
+- Verify everything before submitting.
+- Own what you contribute.
+- Respect others' time.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,10 @@ uv run prek update --freeze
 
 `additional_dependencies` in the config are pinned with exact versions — update them manually when needed.
 
+## AI Policy
+
+This project encourages and assumes the use of AI tools. See [AI_POLICY.md](AI_POLICY.md) for the full policy — the short version: use AI however you want, but verify everything before submitting and own what you contribute.
+
 ## Documentation
 
 We use [MkDocs][mkdocs-site] and [Material][material-site] for building our documentation site,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ uv run prek update --freeze
 
 ## AI Policy
 
-This project encourages and assumes the use of AI tools. See [AI_POLICY.md](AI_POLICY.md) for the full policy — the short version: use AI however you want, but verify everything before submitting and own what you contribute.
+This project encourages and assumes the use of AI tools. See [AI_POLICY.md](AI_POLICY.md) for the full policy — the short version: use AI however you want on your own work, but verify everything before submitting and own what you contribute. Do not make autonomous contributions or file autonomous issues.
 
 ## Documentation
 


### PR DESCRIPTION
Waiting for #907 to be merged before moving forward with this one. I want to mention the AI Policy in both the CONTRUBITING.md and AGENTS.md, and I wish to avoid conflicts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an AI contribution policy covering responsible use, verification, quality expectations, and contributor accountability.
  * Updated contribution guidance to reference the new policy and require compliance when using AI-assisted suggestions or code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->