### PR TITLE
ci: added pre-commit config for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,22 @@ updates:
       - "TomerFi"
       - "thecode"
       - "YogevBokobza"
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - "type: dependencies"
+    commit-message:
+      prefix: "ci"
+    rebase-strategy: disabled
+    assignees:
+      - "TomerFi"
+      - "thecode"
+      - "YogevBokobza"
+    groups:
+      pre-commit-hooks:
+        patterns:
+          - "*"
+        update-type: "all"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ uv run mkdocs build                           # docs
 
 ## Prek Hooks
 
-Hook repos are pinned to commit SHAs. The agent may remind users to update dependencies (`uv run prek update --freeze`) and to update `additional_dependencies` manually. **Always use `--freeze`**; without it, prek update replaces SHAs with tags. The agent should check if hooks are installed (`.git/hooks/pre-commit`) and remind the user to install them if not.
+Hook repos are pinned to commit SHAs. Dependabot handles regular updates automatically with a weekly cadence. For manual updates, use `uv run prek update --freeze`. **Always use `--freeze`** — without it, prek update replaces SHAs with tags. `additional_dependencies` are pinned with exact versions and must be updated manually in the config file. The agent should check if hooks are installed (`.git/hooks/pre-commit`) and remind the user to install them if not.
 
 ## Documentation (mkdocs)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ Update hook dependencies occasionally:
 uv run prek update --freeze
 ```
 
-`additional_dependencies` in the config are pinned with exact versions — update them manually when needed.
+`additional_dependencies` in the config are pinned with exact versions — update them manually in the config file when needed.
 
 ## AI Policy
 


### PR DESCRIPTION
Add Dependabot support for `pre-commit` hooks.

**Changes:**

- Add Dependabot config with `pre-commit` ecosystem — weekly cadence, grouped into a single PR
- Update AGENTS.md and CONTRIBUTING.md to reflect Dependabot handling regular updates (`additional_dependencies` update remains manual)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly checks for pre-commit hook updates.
  * Grouped related hook updates and standardized update labeling.

* **Documentation**
  * Clarified which hook dependencies are updated automatically and which pinned versions require manual updates.
  * Updated contributor guidance to reflect the revised maintenance process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->