### PR TITLE
fix: regenerate uv.lock after version bump in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,9 +103,12 @@ jobs:
           key: project.version
           value: ${{ steps.bumper.outputs.dev }}
 
+      - name: Update lockfile for dev version
+        run: uv lock
+
       - name: Commit and push
         run: |
-          git add pyproject.toml
+          git add pyproject.toml uv.lock
           git commit -m "build: bump version to ${{ steps.bumper.outputs.dev }} [skip ci]"
           git push
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,9 +74,12 @@ jobs:
           key: project.version
           value: ${{ steps.bumper.outputs.next }}
 
+      - name: Update lockfile for new version
+        run: uv lock
+
       - name: Commit, tag, and push
         run: |
-          git add pyproject.toml
+          git add pyproject.toml uv.lock
           git commit -m "build: bump version to ${{ steps.bumper.outputs.next }} [skip ci]"
           git push
           git tag ${{ steps.bumper.outputs.next }} -m "${{ steps.bumper.outputs.next }}"


### PR DESCRIPTION
## Problem

The release workflow bumps the version in `pyproject.toml` (line 77-83), then runs `uv sync --locked --group docs` (line 86). Since the lockfile still reflects the old version, `--locked` refuses to proceed.

The same step works in pr.yml because PRs never bump the version — pyproject.toml matches uv.lock.

## Fix

1. Add `uv lock` after the version bump to regenerate the lockfile
2. Include `uv.lock` in the version bump commit alongside `pyproject.toml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release process to keep dependency lock information synchronized with each new release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->