### PR TITLE
fix: allow durations of 24 hours or more in seconds_to_iso_time

### DIFF
--- a/src/aioswitcher/api/messages.py
+++ b/src/aioswitcher/api/messages.py
@@ -30,7 +30,7 @@ from ..device import (
 from ..device.tools import (
     get_light_discovery_packet_index,
     get_shutter_discovery_packet_index,
-    seconds_to_iso_time,
+    seconds_to_duration_string,
     watts_to_amps,
 )
 from ..schedule.parser import SwitcherSchedule, get_schedules
@@ -62,7 +62,7 @@ class StateMessageParser:
             + hex_time_left[0:2],
             16,
         )
-        return seconds_to_iso_time(time_left_seconds)
+        return seconds_to_duration_string(time_left_seconds)
 
     def get_time_on(self) -> str:
         """Return how long the device has been on."""
@@ -71,7 +71,7 @@ class StateMessageParser:
             hex_time_on[6:8] + hex_time_on[4:6] + hex_time_on[2:4] + hex_time_on[0:2],
             16,
         )
-        return seconds_to_iso_time(time_on_seconds)
+        return seconds_to_duration_string(time_on_seconds)
 
     def get_auto_shutdown(self) -> str:
         """Return the value of the auto shutdown configuration."""
@@ -83,7 +83,7 @@ class StateMessageParser:
             + hex_auto_off[0:2],
             16,
         )
-        return seconds_to_iso_time(auto_off_seconds)
+        return seconds_to_duration_string(auto_off_seconds)
 
     def get_state(self) -> DeviceState:
         """Return the current device state."""
@@ -191,7 +191,7 @@ class StateMessageParser:
             + hex_time_left[0:2],
             16,
         )
-        return seconds_to_iso_time(time_left_seconds)
+        return seconds_to_duration_string(time_left_seconds)
 
     def get_heater_time_on(self) -> str:
         """Return how long the heater device has been on."""
@@ -200,7 +200,7 @@ class StateMessageParser:
             hex_time_on[6:8] + hex_time_on[4:6] + hex_time_on[2:4] + hex_time_on[0:2],
             16,
         )
-        return seconds_to_iso_time(time_on_seconds)
+        return seconds_to_duration_string(time_on_seconds)
 
     def get_heater_auto_shutdown(self) -> str:
         """Return the value of the heater auto shutdown configuration."""
@@ -212,7 +212,7 @@ class StateMessageParser:
             + hex_auto_off[0:2],
             16,
         )
-        return seconds_to_iso_time(auto_off_seconds)
+        return seconds_to_duration_string(auto_off_seconds)
 
     def get_heater_state(self) -> DeviceState:
         """Return the current heater device state."""

--- a/src/aioswitcher/bridge.py
+++ b/src/aioswitcher/bridge.py
@@ -55,7 +55,7 @@ from .device import (
 from .device.tools import (
     get_light_discovery_packet_index,
     get_shutter_discovery_packet_index,
-    seconds_to_iso_time,
+    seconds_to_duration_string,
     watts_to_amps,
 )
 
@@ -615,7 +615,7 @@ class DatagramParser:
             + hex_auto_shutdown_val[0:2],
             16,
         )
-        return seconds_to_iso_time(int_auto_shutdown_val_secs)
+        return seconds_to_duration_string(int_auto_shutdown_val_secs)
 
     def get_power_consumption(self) -> int:
         """Extract the power consumption from the broadcast message."""
@@ -632,7 +632,7 @@ class DatagramParser:
             + hex_remaining_time[0:2],
             16,
         )
-        return seconds_to_iso_time(int_remaining_time_seconds)
+        return seconds_to_duration_string(int_remaining_time_seconds)
 
     def get_device_type(self) -> DeviceType:
         """Extract the device type from the broadcast message."""
@@ -750,4 +750,4 @@ class DatagramParser:
             + hex_remaining_time[0:2],
             16,
         )
-        return seconds_to_iso_time(int_remaining_time_seconds)
+        return seconds_to_duration_string(int_remaining_time_seconds)

--- a/src/aioswitcher/device/tools.py
+++ b/src/aioswitcher/device/tools.py
@@ -30,7 +30,7 @@ from ..device import DeviceType
 logger = getLogger(__name__)
 
 
-def seconds_to_iso_time(all_seconds: int) -> str:
+def seconds_to_duration_string(all_seconds: int) -> str:
     """Convert seconds to an HH:MM:SS duration string.
 
     Args:

--- a/src/aioswitcher/device/tools.py
+++ b/src/aioswitcher/device/tools.py
@@ -31,20 +31,25 @@ logger = getLogger(__name__)
 
 
 def seconds_to_iso_time(all_seconds: int) -> str:
-    """Convert seconds to iso time.
+    """Convert seconds to an HH:MM:SS duration string.
 
     Args:
         all_seconds: the total number of seconds to convert.
 
     Return:
-        A string representing the converted iso time in %H:%M:%S format.
-        e.g. "02:24:37".
+        A string representing the converted duration in %H:%M:%S format.
+        e.g. "02:24:37". Unlike a time-of-day, the hours component is not
+        capped at 23, so durations of a day or longer are represented
+        correctly, e.g. "195:04:54".
 
     """
+    if all_seconds < 0:
+        raise ValueError("seconds cannot be negative")
+
     minutes, seconds = divmod(int(all_seconds), 60)
     hours, minutes = divmod(minutes, 60)
 
-    return datetime.time(hour=hours, minute=minutes, second=seconds).isoformat()
+    return f"{hours:02}:{minutes:02}:{seconds:02}"
 
 
 def sign_packet_with_crc_key(hex_packet: str) -> str:

--- a/tests/test_device_tools.py
+++ b/tests/test_device_tools.py
@@ -35,7 +35,7 @@ def test_seconds_to_iso_time_with_a_duration_longer_than_a_day_should_not_be_cap
     assert_that(tools.seconds_to_iso_time(702294)).is_equal_to("195:04:54")
 
 
-def test_seconds_to_iso_time_with_a_nagative_value_should_throw_an_error():
+def test_seconds_to_iso_time_with_a_negative_value_should_throw_an_error():
     assert_that(tools.seconds_to_iso_time).raises(
         ValueError
     ).when_called_with(-1).contains("seconds cannot be negative")

--- a/tests/test_device_tools.py
+++ b/tests/test_device_tools.py
@@ -27,16 +27,16 @@ from pytest import mark
 from aioswitcher.device import DeviceType, tools
 
 
-def test_seconds_to_iso_time_with_a_valid_seconds_value_should_return_a_time_string():
-    assert_that(tools.seconds_to_iso_time(86399)).is_equal_to("23:59:59")
+def test_seconds_to_duration_string_with_a_valid_seconds_value_should_return_a_time_string():
+    assert_that(tools.seconds_to_duration_string(86399)).is_equal_to("23:59:59")
 
 
-def test_seconds_to_iso_time_with_a_duration_longer_than_a_day_should_not_be_capped():
-    assert_that(tools.seconds_to_iso_time(702294)).is_equal_to("195:04:54")
+def test_seconds_to_duration_string_with_a_duration_longer_than_a_day_should_not_be_capped():
+    assert_that(tools.seconds_to_duration_string(702294)).is_equal_to("195:04:54")
 
 
-def test_seconds_to_iso_time_with_a_negative_value_should_throw_an_error():
-    assert_that(tools.seconds_to_iso_time).raises(
+def test_seconds_to_duration_string_with_a_negative_value_should_throw_an_error():
+    assert_that(tools.seconds_to_duration_string).raises(
         ValueError
     ).when_called_with(-1).contains("seconds cannot be negative")
 

--- a/tests/test_device_tools.py
+++ b/tests/test_device_tools.py
@@ -31,10 +31,14 @@ def test_seconds_to_iso_time_with_a_valid_seconds_value_should_return_a_time_str
     assert_that(tools.seconds_to_iso_time(86399)).is_equal_to("23:59:59")
 
 
+def test_seconds_to_iso_time_with_a_duration_longer_than_a_day_should_not_be_capped():
+    assert_that(tools.seconds_to_iso_time(702294)).is_equal_to("195:04:54")
+
+
 def test_seconds_to_iso_time_with_a_nagative_value_should_throw_an_error():
     assert_that(tools.seconds_to_iso_time).raises(
         ValueError
-    ).when_called_with(-1).contains("hour must be in 0..23")
+    ).when_called_with(-1).contains("seconds cannot be negative")
 
 
 def test_minutes_to_hexadecimal_seconds_with_correct_minutes_should_return_expected_hex_seconds():


### PR DESCRIPTION
## Problem

`seconds_to_iso_time` builds its result via `datetime.time(hour=hours, ...)`, which raises `ValueError: hour must be in 0..23` whenever the computed hour reaches 24 or more.

This function is used to format *durations* (elapsed seconds), not times-of-day, e.g. `SwitcherStateResponse.time_on` and `.time_left`. As a result, `SwitcherApi.get_state()` fails for any power plug (or other Type 1 device) that has been powered on for 24 hours or longer, surfacing as a misleading:

```
RuntimeError: get state request was not successful
```

## Root cause confirmed against a real device

Using a read-only diagnostic script (login + get-state only, no control packets), a real `SwitcherPowerPlug` on my network returned a valid state response with `time_on = 702294` seconds (195h 04m 54s). Parsing that value raised the `ValueError` above, which `get_state()` converts into the generic `RuntimeError`.

## Fix

- Format the duration manually (`f"{hours:02}:{minutes:02}:{seconds:02}"`) instead of constructing a `datetime.time`, removing the 0-23 hour cap while keeping the existing `HH:MM:SS`-shaped return value and negative-input validation.
- Updated the docstring to clarify this is a duration formatter, not a time-of-day formatter.
- Added a regression test covering a duration beyond 24 hours (`702294` -> `"195:04:54"`), and adjusted the existing negative-value test to match the new error message.

## Testing

- `uv run pytest` - full suite passes (one pre-existing, unrelated clock-boundary flake in `test_schedule_tools.py` that passes in isolation and is unaffected by this change)
- `uv run ruff check` / `uv run ruff format --check` - clean on changed files
- `uv run ty check` - clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Duration formatting now correctly supports values of 24 hours or longer.
  - Negative durations are rejected with a clear validation error.
  - Time output remains consistently formatted as `HH:MM:SS` across device, heater, and automatic shutdown timers.
  - Remaining-time and scheduled shutdown displays now use consistent duration formatting.

- **Tests**
  - Added coverage for multi-day durations, negative-input validation, and timer-related formatting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->